### PR TITLE
integrate ShapePublisher into mp/integrate_camera

### DIFF
--- a/Project/Gem/CMakeLists.txt
+++ b/Project/Gem/CMakeLists.txt
@@ -57,11 +57,18 @@ ly_add_target(
         PUBLIC
             Include
     BUILD_DEPENDENCIES
+        PUBLIC
+            Gem::ROS2.Static
         PRIVATE
             AZ::AzGameFramework
+            AZ::AzFramework
+            AZ::AzToolsFramework
             Gem::Atom_AtomBridge.Static
             Gem::ROS2.Static
+            Gem::LmbrCentral.API
 )
+
+target_depends_on_ros2_packages(${gem_name}.Private.Object std_srvs nav_msgs vision_msgs moveit_msgs)
 
 ly_add_target(
     NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
@@ -77,6 +84,9 @@ ly_add_target(
             Gem::${gem_name}.Private.Object
             AZ::AzCore
             Gem::ROS2.Static
+            AZ::AzGameFramework
+            AZ::AzFramework
+            AZ::AzToolsFramework
 )
 
 target_depends_on_ros2_package(${gem_name}.Private.Object  vision_msgs REQUIRED)

--- a/Project/Gem/ROSCon2023Demo_files.cmake
+++ b/Project/Gem/ROSCon2023Demo_files.cmake
@@ -7,5 +7,7 @@ set(FILES
     Source/ROSCon2023DemoSystemComponent.h
     Source/Vision/IdealVisionSystem.cpp
     Source/Vision/IdealVisionSystem.h
+    Source/PlanningScene/ShapePublisherComponent.h
+    Source/PlanningScene/ShapePublisherComponent.cpp
     enabled_gems.cmake
 )

--- a/Project/Gem/Source/PlanningScene/ShapePublisherComponent.cpp
+++ b/Project/Gem/Source/PlanningScene/ShapePublisherComponent.cpp
@@ -1,0 +1,215 @@
+
+#include "ShapePublisherComponent.h"
+#include "AzCore/Component/TransformBus.h"
+#include "AzCore/Debug/Trace.h"
+#include "AzCore/Math/Quaternion.h"
+#include "AzCore/Math/Random.h"
+#include "AzCore/Math/Transform.h"
+#include "AzCore/Serialization/EditContextConstants.inl"
+#include <AzCore/Component/EntityUtils.h>
+#include <AzCore/Math/Obb.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Components/TransformComponent.h>
+#include <LmbrCentral/Shape/BoxShapeComponentBus.h>
+#include <LmbrCentral/Shape/CylinderShapeComponentBus.h>
+#include <LmbrCentral/Shape/ShapeComponentBus.h>
+#include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/ROS2Bus.h>
+#include <ROS2/ROS2GemUtilities.h>
+#include <rclcpp/qos.hpp>
+
+namespace ROSCon2023Demo
+{
+    void ShapePublisherComponent::Activate()
+    {
+        auto ros2Node = ROS2::ROS2Interface::Get()->GetNode();
+        m_publisher = ros2Node->create_publisher<moveit_msgs::msg::CollisionObject>("/collision_object", 10);
+
+        AZ::TickBus::Handler::BusConnect();
+
+        Publish();
+    }
+
+    void ShapePublisherComponent::Deactivate()
+    {
+        AZ::TickBus::Handler::BusDisconnect();
+    }
+
+    AZStd::string ShapePublisherComponent::GetFrameID() const
+    {
+        auto* ros2Frame = ROS2::Utils::GetGameOrEditorComponent<ROS2::ROS2FrameComponent>(GetEntity());
+        return ros2Frame->GetFrameID();
+    }
+
+    moveit_msgs::msg::CollisionObject ShapePublisherComponent::CreateCollisionObject()
+    {
+        AZ::Crc32 shapeType;
+        LmbrCentral::ShapeComponentRequestsBus::EventResult(shapeType, GetEntityId(), &LmbrCentral::ShapeComponentRequests::GetShapeType);
+
+        if (shapeType == AZ_CRC("Box", 0x08a9483a))
+        {
+            return CreateBoxCollisionObject();
+        }
+
+        if (shapeType == AZ_CRC("Cylinder", 0x9b045bea))
+        {
+            return CreateCylinderCollisionObject();
+        }
+
+        AZ_Warning("ShapePublisherComponent", false, "Unsupported shape type: %d", (int)shapeType);
+        return moveit_msgs::msg::CollisionObject();
+    }
+
+    namespace Internal
+    {
+        geometry_msgs::msg::Pose CreatePose(AZ::Transform tf)
+        {
+            auto translation = tf.GetTranslation();
+            auto rotation = tf.GetRotation();
+            geometry_msgs::msg::Pose box_pose;
+            box_pose.position.x = translation.GetX();
+            box_pose.position.y = translation.GetY();
+            box_pose.position.z = translation.GetZ();
+            box_pose.orientation.x = rotation.GetX();
+            box_pose.orientation.y = rotation.GetY();
+            box_pose.orientation.z = rotation.GetZ();
+            box_pose.orientation.w = rotation.GetW();
+
+            return box_pose;
+        }
+    } // namespace Internal
+
+    moveit_msgs::msg::CollisionObject ShapePublisherComponent::CreateObject(
+        shape_msgs::msg::SolidPrimitive primitive, geometry_msgs::msg::Pose pose)
+    {
+        moveit_msgs::msg::CollisionObject collision_object;
+
+        collision_object.header.frame_id = GetFrameID().c_str();
+        collision_object.id = m_objectId.c_str();
+        collision_object.primitives.push_back(primitive);
+        collision_object.primitive_poses.push_back(pose);
+        collision_object.operation = collision_object.ADD;
+
+        return collision_object;
+    }
+
+    moveit_msgs::msg::CollisionObject ShapePublisherComponent::CreateCylinderCollisionObject()
+    {
+        LmbrCentral::CylinderShapeConfig cylinderConfig = LmbrCentral::CylinderShapeConfig();
+        LmbrCentral::CylinderShapeComponentRequestsBus::EventResult(
+            cylinderConfig, GetEntityId(), &LmbrCentral::CylinderShapeComponentRequests::GetCylinderConfiguration);
+
+        shape_msgs::msg::SolidPrimitive primitive;
+        primitive.type = primitive.CYLINDER;
+        primitive.dimensions.resize(2);
+        primitive.dimensions[primitive.CYLINDER_HEIGHT] = cylinderConfig.m_height;
+        primitive.dimensions[primitive.CYLINDER_RADIUS] = cylinderConfig.m_radius;
+
+        auto pose = Internal::CreatePose(AZ::Transform::CreateIdentity());
+
+        return CreateObject(primitive, pose);
+    }
+
+    moveit_msgs::msg::CollisionObject ShapePublisherComponent::CreateBoxCollisionObject()
+    {
+        LmbrCentral::BoxShapeConfig boxConfig = LmbrCentral::BoxShapeConfig();
+        LmbrCentral::BoxShapeComponentRequestsBus::EventResult(
+            boxConfig, GetEntityId(), &LmbrCentral::BoxShapeComponentRequests::GetBoxConfiguration);
+
+        auto boxDimensions = boxConfig.m_dimensions;
+        auto offset = boxConfig.m_translationOffset;
+
+        auto tm = AZ::Transform::CreateTranslation(offset);
+
+        bool isAxisAligned = false;
+        LmbrCentral::BoxShapeComponentRequestsBus::EventResult(
+            isAxisAligned, GetEntityId(), &LmbrCentral::BoxShapeComponentRequests::IsTypeAxisAligned);
+
+        if (isAxisAligned)
+        {
+            tm.SetRotation(AZ::Quaternion::CreateIdentity());
+        }
+
+        shape_msgs::msg::SolidPrimitive primitive;
+        primitive.type = primitive.BOX;
+        primitive.dimensions.push_back(boxDimensions.GetX());
+        primitive.dimensions.push_back(boxDimensions.GetY());
+        primitive.dimensions.push_back(boxDimensions.GetZ());
+
+        auto pose = Internal::CreatePose(tm);
+
+        return CreateObject(primitive, pose);
+    }
+
+    void ShapePublisherComponent::Publish()
+    {
+        auto collisionObject = CreateCollisionObject();
+        m_publisher->publish(collisionObject);
+    }
+
+    void ShapePublisherComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<ShapePublisherComponent, AZ::Component>()
+                ->Field("ObjectName", &ShapePublisherComponent::m_objectId)
+                ->Version(1);
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<ShapePublisherComponent>("ShapePublisherComponent", "Publishes CollisionObject data about shape.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "ShapePublisher")
+                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+                    ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/Component_Placeholder.svg")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ShapePublisherComponent::m_objectId,
+                        "Object Id",
+                        "Id of the object, used as id in CollisionObject messages. Should be unique.");
+            }
+        }
+    }
+
+    void ShapePublisherComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("ShapePublisherComponentService"));
+    }
+
+    void ShapePublisherComponent::GetIncompatibleServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+    }
+
+    void ShapePublisherComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC("ShapeService", 0xe86aa5fe));
+        required.push_back(AZ_CRC_CE("ROS2Frame"));
+    }
+
+    void ShapePublisherComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+    }
+
+    void ShapePublisherComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
+        AZ_Assert(m_frequency > 0.f, "ShapePublisher frequency must be greater than zero");
+        auto frameTime = 1.f / m_frequency;
+
+        m_timeElapsedSinceLastTick += deltaTime;
+        if (m_timeElapsedSinceLastTick < frameTime)
+        {
+            return;
+        }
+
+        m_timeElapsedSinceLastTick -= frameTime;
+        if (deltaTime > frameTime)
+        { // Frequency higher than possible, not catching up, just keep going with each frame.
+            m_timeElapsedSinceLastTick = 0.0f;
+        }
+
+        Publish();
+    }
+
+} // namespace ROSCon2023Demo

--- a/Project/Gem/Source/PlanningScene/ShapePublisherComponent.h
+++ b/Project/Gem/Source/PlanningScene/ShapePublisherComponent.h
@@ -1,0 +1,52 @@
+
+#pragma once
+
+#include "AzCore/Component/EntityId.h"
+#include "AzCore/Math/Transform.h"
+#include "AzCore/std/string/string.h"
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <moveit_msgs/msg/collision_object.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_srvs/srv/empty.hpp>
+#include <std_srvs/srv/trigger.hpp>
+
+namespace ROSCon2023Demo
+{
+
+    class ShapePublisherComponent
+        : public AZ::Component
+        , public AZ::TickBus::Handler
+    {
+    public:
+        AZ_COMPONENT(ShapePublisherComponent, "{DFEE0399-B3EB-4D5F-98F4-D966C3EAFE90}", AZ::Component);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+
+    protected:
+        void Activate() override;
+        void Deactivate() override;
+
+    private:
+        moveit_msgs::msg::CollisionObject CreateCollisionObject();
+        moveit_msgs::msg::CollisionObject CreateBoxCollisionObject();
+        moveit_msgs::msg::CollisionObject CreateCylinderCollisionObject();
+        moveit_msgs::msg::CollisionObject CreateObject(shape_msgs::msg::SolidPrimitive primitive, geometry_msgs::msg::Pose pose);
+
+        AZStd::string GetFrameID() const;
+
+        void Publish();
+
+        rclcpp::Publisher<moveit_msgs::msg::CollisionObject>::SharedPtr m_publisher;
+        AZStd::string m_objectId = "unique_object_id";
+        float m_frequency = 1.5f;
+        float m_timeElapsedSinceLastTick = 0.0f;
+    };
+} // namespace ROSCon2023Demo

--- a/Project/Gem/Source/ROSCon2023DemoModule.cpp
+++ b/Project/Gem/Source/ROSCon2023DemoModule.cpp
@@ -2,6 +2,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 
+#include "PlanningScene/ShapePublisherComponent.h"
 #include "ROSCon2023DemoSystemComponent.h"
 #include "Vision/IdealVisionSystem.h"
 
@@ -21,6 +22,7 @@ namespace ROSCon2023Demo
             m_descriptors.insert(m_descriptors.end(), {
                 ROSCon2023DemoSystemComponent::CreateDescriptor(),
                 ROS2::Demo::IdealVisionSystem::CreateDescriptor(),
+                ShapePublisherComponent::CreateDescriptor()
             });
         }
 

--- a/Project/Levels/single2_published_objects/single2_published_objects.prefab
+++ b/Project/Levels/single2_published_objects/single2_published_objects.prefab
@@ -1,0 +1,794 @@
+{
+    "ContainerEntity": {
+        "Id": "Entity_[1146574390643]",
+        "Name": "Level",
+        "Components": {
+            "Component_[10641544592923449938]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 10641544592923449938
+            },
+            "Component_[12039882709170782873]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 12039882709170782873
+            },
+            "Component_[12265484671603697631]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12265484671603697631
+            },
+            "Component_[14126657869720434043]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 14126657869720434043,
+                "Child Entity Order": [
+                    "Entity_[1176639161715]"
+                ]
+            },
+            "Component_[15230859088967841193]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 15230859088967841193,
+                "Parent Entity": ""
+            },
+            "Component_[16239496886950819870]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 16239496886950819870
+            },
+            "Component_[5688118765544765547]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 5688118765544765547
+            },
+            "Component_[7247035804068349658]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 7247035804068349658
+            },
+            "Component_[9307224322037797205]": {
+                "$type": "EditorLockComponent",
+                "Id": 9307224322037797205
+            },
+            "Component_[9562516168917670048]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 9562516168917670048
+            },
+            "LocalViewBookmarkComponent": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 6130601455871436975,
+                "LocalBookmarkFileName": "single2_1690293620770570209.setreg"
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1155164325235]": {
+            "Id": "Entity_[1155164325235]",
+            "Name": "Sun",
+            "Components": {
+                "Component_[13620450453324765907]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13620450453324765907
+                },
+                "Component_[2134313378593666258]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 2134313378593666258
+                },
+                "Component_[234010807770404186]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 234010807770404186
+                },
+                "Component_[2970359110423865725]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2970359110423865725
+                },
+                "Component_[3722854130373041803]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3722854130373041803
+                },
+                "Component_[5992533738676323195]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5992533738676323195
+                },
+                "Component_[7378860763541895402]": {
+                    "$type": "AZ::Render::EditorDirectionalLightComponent",
+                    "Id": 7378860763541895402,
+                    "Controller": {
+                        "Configuration": {
+                            "Intensity": 1.0,
+                            "CameraEntityId": "",
+                            "ShadowFilterMethod": 1
+                        }
+                    }
+                },
+                "Component_[7892834440890947578]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7892834440890947578,
+                    "Parent Entity": "Entity_[1176639161715]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            13.487043380737305
+                        ],
+                        "Rotate": [
+                            -76.13099670410156,
+                            -0.847000002861023,
+                            -15.8100004196167
+                        ]
+                    }
+                },
+                "Component_[8599729549570828259]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8599729549570828259
+                },
+                "Component_[952797371922080273]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 952797371922080273
+                }
+            }
+        },
+        "Entity_[1159459292531]": {
+            "Id": "Entity_[1159459292531]",
+            "Name": "Ground",
+            "Components": {
+                "Component_[12260880513256986252]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12260880513256986252
+                },
+                "Component_[13711420870643673468]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13711420870643673468
+                },
+                "Component_[138002849734991713]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 138002849734991713
+                },
+                "Component_[16578565737331764849]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16578565737331764849,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[16919232076966545697]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16919232076966545697
+                },
+                "Component_[4228479570410194639]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4228479570410194639
+                },
+                "Component_[5182430712893438093]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 5182430712893438093
+                },
+                "Component_[5245524694917323904]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5245524694917323904,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                512.0,
+                                512.0,
+                                1.0
+                            ]
+                        }
+                    },
+                    "DebugDrawSettings": {
+                        "LocallyEnabled": false
+                    }
+                },
+                "Component_[5675108321710651991]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 5675108321710651991,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{0CD745C0-6AA8-569A-A68A-73A3270986C4}",
+                                    "subId": 277889906
+                                },
+                                "assetHint": "objects/groudplane/groundplane_512x512m.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[5681893399601237518]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5681893399601237518
+                },
+                "Component_[592692962543397545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 592692962543397545
+                },
+                "Component_[7090012899106946164]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7090012899106946164
+                },
+                "Component_[9410832619875640998]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9410832619875640998
+                }
+            }
+        },
+        "Entity_[1163754259827]": {
+            "Id": "Entity_[1163754259827]",
+            "Name": "Camera",
+            "Components": {
+                "Component_[11895140916889160460]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11895140916889160460
+                },
+                "Component_[16880285896855930892]": {
+                    "$type": "{CA11DA46-29FF-4083-B5F6-E02C3A8C3A3D} EditorCameraComponent",
+                    "Id": 16880285896855930892,
+                    "Controller": {
+                        "Configuration": {
+                            "Field of View": 60.0
+                        }
+                    }
+                },
+                "Component_[17187464423780271193]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17187464423780271193
+                },
+                "Component_[17495696818315413311]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17495696818315413311
+                },
+                "Component_[18086214374043522055]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18086214374043522055,
+                    "Parent Entity": "Entity_[1176639161715]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.6641418933868408,
+                            0.2748779356479645,
+                            3.0908408164978027
+                        ],
+                        "Rotate": [
+                            -16.892663955688477,
+                            -66.00496673583984,
+                            71.61271667480469
+                        ]
+                    }
+                },
+                "Component_[2654521436129313160]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2654521436129313160
+                },
+                "Component_[5265045084611556958]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5265045084611556958
+                },
+                "Component_[7169798125182238623]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7169798125182238623
+                },
+                "Component_[7255796294953281766]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 7255796294953281766,
+                    "m_template": {
+                        "$type": "FlyCameraInputComponent",
+                        "Move Speed": 1.0,
+                        "Mouse Sensitivity": 0.0
+                    }
+                },
+                "Component_[8866210352157164042]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8866210352157164042
+                },
+                "Component_[9129253381063760879]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9129253381063760879
+                }
+            }
+        },
+        "Entity_[1168049227123]": {
+            "Id": "Entity_[1168049227123]",
+            "Name": "Grid",
+            "Components": {
+                "Component_[11443347433215807130]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11443347433215807130
+                },
+                "Component_[14249419413039427459]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14249419413039427459
+                },
+                "Component_[15448581635946161318]": {
+                    "$type": "AZ::Render::EditorGridComponent",
+                    "Id": 15448581635946161318,
+                    "Controller": {
+                        "Configuration": {
+                            "primarySpacing": 4.0,
+                            "primaryColor": [
+                                0.501960813999176,
+                                0.501960813999176,
+                                0.501960813999176
+                            ],
+                            "secondarySpacing": 0.5,
+                            "secondaryColor": [
+                                0.250980406999588,
+                                0.250980406999588,
+                                0.250980406999588
+                            ]
+                        }
+                    }
+                },
+                "Component_[1843303322527297409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1843303322527297409
+                },
+                "Component_[380249072065273654]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 380249072065273654,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[7476660583684339787]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7476660583684339787
+                },
+                "Component_[7557626501215118375]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7557626501215118375
+                },
+                "Component_[7984048488947365511]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7984048488947365511
+                },
+                "Component_[8118181039276487398]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8118181039276487398
+                },
+                "Component_[9189909764215270515]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9189909764215270515
+                }
+            }
+        },
+        "Entity_[1176639161715]": {
+            "Id": "Entity_[1176639161715]",
+            "Name": "Atom Default Environment",
+            "Components": {
+                "Component_[10757302973393310045]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10757302973393310045,
+                    "Parent Entity": "Entity_[1146574390643]"
+                },
+                "Component_[14505817420424255464]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14505817420424255464,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10757302973393310045
+                        }
+                    ]
+                },
+                "Component_[14988041764659020032]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14988041764659020032
+                },
+                "Component_[15900837685796817138]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15900837685796817138
+                },
+                "Component_[3298767348226484884]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3298767348226484884
+                },
+                "Component_[4076975109609220594]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4076975109609220594
+                },
+                "Component_[5679760548946028854]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5679760548946028854
+                },
+                "Component_[5855590796136709437]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5855590796136709437,
+                    "Child Entity Order": [
+                        "Instance_[2082921034728]/ContainerEntity",
+                        "Entity_[1155164325235]",
+                        "Entity_[1180934129011]",
+                        "Entity_[1168049227123]",
+                        "Entity_[1163754259827]",
+                        "Entity_[1159459292531]"
+                    ]
+                },
+                "Component_[9277695270015777859]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9277695270015777859
+                }
+            }
+        },
+        "Entity_[1180934129011]": {
+            "Id": "Entity_[1180934129011]",
+            "Name": "Global Sky",
+            "Components": {
+                "Component_[11231930600558681245]": {
+                    "$type": "AZ::Render::EditorHDRiSkyboxComponent",
+                    "Id": 11231930600558681245,
+                    "Controller": {
+                        "Configuration": {
+                            "CubemapAsset": {
+                                "assetId": {
+                                    "guid": "{215E47FD-D181-5832-B1AB-91673ABF6399}",
+                                    "subId": 1000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_skyboxcm.exr.streamingimage"
+                            }
+                        }
+                    }
+                },
+                "Component_[1428633914413949476]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1428633914413949476
+                },
+                "Component_[14936200426671614999]": {
+                    "$type": "AZ::Render::EditorImageBasedLightComponent",
+                    "Id": 14936200426671614999,
+                    "Controller": {
+                        "Configuration": {
+                            "diffuseImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 3000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_ibldiffuse.exr.streamingimage"
+                            },
+                            "specularImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 2000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_iblspecular.exr.streamingimage"
+                            }
+                        }
+                    }
+                },
+                "Component_[14994774102579326069]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14994774102579326069
+                },
+                "Component_[15417479889044493340]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15417479889044493340
+                },
+                "Component_[15826613364991382688]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15826613364991382688
+                },
+                "Component_[1665003113283562343]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1665003113283562343
+                },
+                "Component_[3704934735944502280]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3704934735944502280
+                },
+                "Component_[5698542331457326479]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5698542331457326479
+                },
+                "Component_[6644513399057217122]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6644513399057217122,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[931091830724002070]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 931091830724002070
+                }
+            }
+        }
+    },
+    "Instances": {
+        "Instance_[2082921034728]": {
+            "Source": "Prefabs/Cell.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
+                    "value": "../Entity_[1176639161715]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[381763642777368]/Components/EditorEntitySortComponent/Child Entity Order/1",
+                    "value": "Instance_[1865408112624287]/ContainerEntity"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[381763642777368]/Components/EditorEntitySortComponent/Child Entity Order/2",
+                    "value": "Instance_[12382254012170911]/ContainerEntity"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[381763642777368]/Components/EditorEntitySortComponent/Child Entity Order/3",
+                    "value": "Instance_[4980853547463014]/ContainerEntity"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[381763642777368]/Components/EditorEntitySortComponent/Child Entity Order/4",
+                    "value": "Instance_[1205512827607618]/ContainerEntity"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[381763642777368]/Components/EditorEntitySortComponent/Child Entity Order/5",
+                    "value": "Instance_[1205499942705730]/ContainerEntity"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[381763642777368]/Components/EditorEntitySortComponent/Child Entity Order/6",
+                    "value": "Instance_[51574540204469]/ContainerEntity"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[381763642777368]/Components/EditorEntitySortComponent/Child Entity Order/7",
+                    "value": "Instance_[51561655302581]/ContainerEntity"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[381763642777368]/Components/EditorEntitySortComponent/Child Entity Order/8",
+                    "value": "Entity_[1089616773913]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[1205499942705730]/Entities/Entity_[191977789557570]/Name",
+                    "value": "Box6"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[1205512827607618]/Entities/Entity_[191977789557570]/Name",
+                    "value": "Box5"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[12382254012170911]/ContainerEntity/Name",
+                    "value": "Box3"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[12382254012170911]/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
+                    "value": -6.959403991699219
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[12382254012170911]/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
+                    "value": 7.687471389770508
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[12382254012170911]/ContainerEntity/Components/TransformComponent/Transform Data/Translate/2",
+                    "value": 0.2500579357147217
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[12382254012170911]/Entities/Entity_[191977789557570]/Name",
+                    "value": "Box3"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2814779357286]/Components/EditorArticulationLinkComponent/ArticulationConfiguration/Local Position/0",
+                    "value": 2.1419169805390224e31
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2814779357286]/Components/EditorArticulationLinkComponent/ArticulationConfiguration/Local Position/1",
+                    "value": 1.9054813738141823e30
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2814779357286]/Components/EditorArticulationLinkComponent/ArticulationConfiguration/Local Position/2",
+                    "value": 4.196843709000072e30
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2814779357286]/Components/EditorArticulationLinkComponent/ArticulationConfiguration/Local Rotation/0",
+                    "value": 180.0
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2814779357286]/Components/EditorArticulationLinkComponent/ArticulationConfiguration/Local Rotation/1",
+                    "value": -1.4470072788027816e-38
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2814779357286]/Components/EditorArticulationLinkComponent/ArticulationConfiguration/Local Rotation/2",
+                    "value": 134.99996948242188
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2840549161062]/Components/EditorColliderComponent/ShapeConfiguration/Box/Configuration/0",
+                    "value": 0.20000000298023224
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2844844128358]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": true
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[4980853547463014]/Entities/Entity_[191977789557570]/Name",
+                    "value": "Box4"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[51561655302581]/Entities/Entity_[191977789557570]/Name",
+                    "value": "Box7"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[51574540204469]/Entities/Entity_[191977789557570]/Name",
+                    "value": "Box8"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Instances/Instance_[1865420997526175]"
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[64250519576458]/Entities/Entity_[1189702382781087]/Components/EditorBoxShapeComponent",
+                    "value": {
+                        "$type": "EditorBoxShapeComponent",
+                        "Id": 16572550711862492149,
+                        "Visible": true,
+                        "GameView": false,
+                        "DisplayFilled": true,
+                        "ShapeColor": [
+                            1.0,
+                            1.0,
+                            0.7799999713897705,
+                            0.4000000059604645
+                        ],
+                        "BoxShape": {
+                            "Configuration": {
+                                "DrawColor": [
+                                    1.0,
+                                    1.0,
+                                    0.7799999713897705,
+                                    0.4000000059604645
+                                ],
+                                "IsFilled": true,
+                                "Dimensions": [
+                                    0.9595853090286255,
+                                    0.6109374165534973,
+                                    0.9638571739196777
+                                ],
+                                "TranslationOffset": [
+                                    0.0006024999893270433,
+                                    0.3016800880432129,
+                                    0.000539399974513799
+                                ]
+                            }
+                        },
+                        "ComponentMode": {}
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[64250519576458]/Entities/Entity_[1189702382781087]/Components/EditorColliderComponent/DebugDrawSettings/LocallyEnabled",
+                    "value": false
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[64250519576458]/Entities/Entity_[1189702382781087]/Components/EditorColliderComponent_2/DebugDrawSettings/LocallyEnabled",
+                    "value": false
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[64250519576458]/Entities/Entity_[1189702382781087]/Components/ROS2FrameComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 12663201011687615351,
+                        "m_template": {
+                            "$type": "ROS2FrameComponent",
+                            "Id": 0,
+                            "Namespace Configuration": {
+                                "Namespace Strategy": 1,
+                                "Namespace": ""
+                            },
+                            "Frame Name": "table_main_frame",
+                            "Joint Name": "",
+                            "Publish Transform": true,
+                            "Force Dynamic": false
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[64250519576458]/Entities/Entity_[1189702382781087]/Components/ShapePublisherComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 13709589829018386901,
+                        "m_template": {
+                            "$type": "ShapePublisherComponent",
+                            "Id": 0,
+                            "ObjectName": "table"
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[381716398137112]/Components/EditorBoxShapeComponent",
+                    "value": {
+                        "$type": "EditorBoxShapeComponent",
+                        "Id": 7731915972024734089,
+                        "Visible": true,
+                        "GameView": false,
+                        "DisplayFilled": true,
+                        "ShapeColor": [
+                            1.0,
+                            1.0,
+                            0.7799999713897705,
+                            0.4000000059604645
+                        ],
+                        "BoxShape": {
+                            "Configuration": {
+                                "DrawColor": [
+                                    1.0,
+                                    1.0,
+                                    0.7799999713897705,
+                                    0.4000000059604645
+                                ],
+                                "IsFilled": true,
+                                "Dimensions": [
+                                    2.0,
+                                    0.75,
+                                    0.15000000596046448
+                                ],
+                                "TranslationOffset": [
+                                    0.8936123847961426,
+                                    -0.17844432592391968,
+                                    0.07810574769973755
+                                ]
+                            }
+                        },
+                        "ComponentMode": {}
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[381716398137112]/Components/ROS2FrameComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 10649253492636416526,
+                        "m_template": {
+                            "$type": "ROS2FrameComponent",
+                            "Id": 0,
+                            "Namespace Configuration": {
+                                "Namespace Strategy": 1,
+                                "Namespace": ""
+                            },
+                            "Frame Name": "conveyor_frame",
+                            "Joint Name": "",
+                            "Publish Transform": true,
+                            "Force Dynamic": false
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[381716398137112]/Components/ShapePublisherComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 9721725260774116648,
+                        "m_template": {
+                            "$type": "ShapePublisherComponent",
+                            "Id": 0,
+                            "ObjectName": "conveyor"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/Project/Levels/single3/single3.prefab
+++ b/Project/Levels/single3/single3.prefab
@@ -1,0 +1,1054 @@
+{
+    "ContainerEntity": {
+        "Id": "Entity_[1146574390643]",
+        "Name": "Level",
+        "Components": {
+            "Component_[10641544592923449938]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 10641544592923449938
+            },
+            "Component_[12039882709170782873]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 12039882709170782873
+            },
+            "Component_[12265484671603697631]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12265484671603697631
+            },
+            "Component_[14126657869720434043]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 14126657869720434043,
+                "Child Entity Order": [
+                    "Entity_[1176639161715]",
+                    "Entity_[3211622250490]"
+                ]
+            },
+            "Component_[15230859088967841193]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 15230859088967841193,
+                "Parent Entity": ""
+            },
+            "Component_[16239496886950819870]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 16239496886950819870
+            },
+            "Component_[5688118765544765547]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 5688118765544765547
+            },
+            "Component_[7247035804068349658]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 7247035804068349658
+            },
+            "Component_[9307224322037797205]": {
+                "$type": "EditorLockComponent",
+                "Id": 9307224322037797205
+            },
+            "Component_[9562516168917670048]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 9562516168917670048
+            },
+            "LocalViewBookmarkComponent": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 6130601455871436975,
+                "LocalBookmarkFileName": "single2_1690293620770570209.setreg"
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1155164325235]": {
+            "Id": "Entity_[1155164325235]",
+            "Name": "Sun",
+            "Components": {
+                "Component_[13620450453324765907]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13620450453324765907
+                },
+                "Component_[2134313378593666258]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 2134313378593666258
+                },
+                "Component_[234010807770404186]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 234010807770404186
+                },
+                "Component_[2970359110423865725]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2970359110423865725
+                },
+                "Component_[3722854130373041803]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3722854130373041803
+                },
+                "Component_[5992533738676323195]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5992533738676323195
+                },
+                "Component_[7378860763541895402]": {
+                    "$type": "AZ::Render::EditorDirectionalLightComponent",
+                    "Id": 7378860763541895402,
+                    "Controller": {
+                        "Configuration": {
+                            "Intensity": 1.0,
+                            "CameraEntityId": "",
+                            "ShadowFilterMethod": 1
+                        }
+                    }
+                },
+                "Component_[7892834440890947578]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7892834440890947578,
+                    "Parent Entity": "Entity_[1176639161715]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            13.487043380737305
+                        ],
+                        "Rotate": [
+                            -76.13099670410156,
+                            -0.847000002861023,
+                            -15.8100004196167
+                        ]
+                    }
+                },
+                "Component_[8599729549570828259]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8599729549570828259
+                },
+                "Component_[952797371922080273]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 952797371922080273
+                }
+            }
+        },
+        "Entity_[1159459292531]": {
+            "Id": "Entity_[1159459292531]",
+            "Name": "Ground",
+            "Components": {
+                "Component_[12260880513256986252]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12260880513256986252
+                },
+                "Component_[13711420870643673468]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13711420870643673468
+                },
+                "Component_[138002849734991713]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 138002849734991713
+                },
+                "Component_[16578565737331764849]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16578565737331764849,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[16919232076966545697]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16919232076966545697
+                },
+                "Component_[4228479570410194639]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4228479570410194639
+                },
+                "Component_[5182430712893438093]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 5182430712893438093
+                },
+                "Component_[5245524694917323904]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5245524694917323904,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                512.0,
+                                512.0,
+                                1.0
+                            ]
+                        }
+                    },
+                    "DebugDrawSettings": {
+                        "LocallyEnabled": false
+                    }
+                },
+                "Component_[5675108321710651991]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 5675108321710651991,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{0CD745C0-6AA8-569A-A68A-73A3270986C4}",
+                                    "subId": 277889906
+                                },
+                                "assetHint": "objects/groudplane/groundplane_512x512m.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[5681893399601237518]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5681893399601237518
+                },
+                "Component_[592692962543397545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 592692962543397545
+                },
+                "Component_[7090012899106946164]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7090012899106946164
+                },
+                "Component_[9410832619875640998]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9410832619875640998
+                }
+            }
+        },
+        "Entity_[1163754259827]": {
+            "Id": "Entity_[1163754259827]",
+            "Name": "Camera",
+            "Components": {
+                "Component_[11895140916889160460]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11895140916889160460
+                },
+                "Component_[16880285896855930892]": {
+                    "$type": "{CA11DA46-29FF-4083-B5F6-E02C3A8C3A3D} EditorCameraComponent",
+                    "Id": 16880285896855930892,
+                    "Controller": {
+                        "Configuration": {
+                            "Field of View": 60.0
+                        }
+                    }
+                },
+                "Component_[17187464423780271193]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17187464423780271193
+                },
+                "Component_[17495696818315413311]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17495696818315413311
+                },
+                "Component_[18086214374043522055]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18086214374043522055,
+                    "Parent Entity": "Entity_[1176639161715]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.6641418933868408,
+                            0.2748779356479645,
+                            3.0908408164978027
+                        ],
+                        "Rotate": [
+                            -16.892663955688477,
+                            -66.00496673583984,
+                            71.61271667480469
+                        ]
+                    }
+                },
+                "Component_[2654521436129313160]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2654521436129313160
+                },
+                "Component_[5265045084611556958]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5265045084611556958
+                },
+                "Component_[7169798125182238623]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7169798125182238623
+                },
+                "Component_[7255796294953281766]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 7255796294953281766,
+                    "m_template": {
+                        "$type": "FlyCameraInputComponent",
+                        "Move Speed": 1.0,
+                        "Mouse Sensitivity": 0.0
+                    }
+                },
+                "Component_[8866210352157164042]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8866210352157164042
+                },
+                "Component_[9129253381063760879]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9129253381063760879
+                }
+            }
+        },
+        "Entity_[1168049227123]": {
+            "Id": "Entity_[1168049227123]",
+            "Name": "Grid",
+            "Components": {
+                "Component_[11443347433215807130]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11443347433215807130
+                },
+                "Component_[14249419413039427459]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14249419413039427459
+                },
+                "Component_[15448581635946161318]": {
+                    "$type": "AZ::Render::EditorGridComponent",
+                    "Id": 15448581635946161318,
+                    "Controller": {
+                        "Configuration": {
+                            "primarySpacing": 4.0,
+                            "primaryColor": [
+                                0.501960813999176,
+                                0.501960813999176,
+                                0.501960813999176
+                            ],
+                            "secondarySpacing": 0.5,
+                            "secondaryColor": [
+                                0.250980406999588,
+                                0.250980406999588,
+                                0.250980406999588
+                            ]
+                        }
+                    }
+                },
+                "Component_[1843303322527297409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1843303322527297409
+                },
+                "Component_[380249072065273654]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 380249072065273654,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[7476660583684339787]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7476660583684339787
+                },
+                "Component_[7557626501215118375]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7557626501215118375
+                },
+                "Component_[7984048488947365511]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7984048488947365511
+                },
+                "Component_[8118181039276487398]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8118181039276487398
+                },
+                "Component_[9189909764215270515]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9189909764215270515
+                }
+            }
+        },
+        "Entity_[1176639161715]": {
+            "Id": "Entity_[1176639161715]",
+            "Name": "Atom Default Environment",
+            "Components": {
+                "Component_[10757302973393310045]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10757302973393310045,
+                    "Parent Entity": "Entity_[1146574390643]"
+                },
+                "Component_[14505817420424255464]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14505817420424255464,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10757302973393310045
+                        }
+                    ]
+                },
+                "Component_[14988041764659020032]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14988041764659020032
+                },
+                "Component_[15900837685796817138]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15900837685796817138
+                },
+                "Component_[3298767348226484884]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3298767348226484884
+                },
+                "Component_[4076975109609220594]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4076975109609220594
+                },
+                "Component_[5679760548946028854]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5679760548946028854
+                },
+                "Component_[5855590796136709437]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5855590796136709437,
+                    "Child Entity Order": [
+                        "Entity_[1155164325235]",
+                        "Entity_[1180934129011]",
+                        "Entity_[1168049227123]",
+                        "Entity_[1163754259827]",
+                        "Entity_[1159459292531]"
+                    ]
+                },
+                "Component_[9277695270015777859]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9277695270015777859
+                }
+            }
+        },
+        "Entity_[1180934129011]": {
+            "Id": "Entity_[1180934129011]",
+            "Name": "Global Sky",
+            "Components": {
+                "Component_[11231930600558681245]": {
+                    "$type": "AZ::Render::EditorHDRiSkyboxComponent",
+                    "Id": 11231930600558681245,
+                    "Controller": {
+                        "Configuration": {
+                            "CubemapAsset": {
+                                "assetId": {
+                                    "guid": "{215E47FD-D181-5832-B1AB-91673ABF6399}",
+                                    "subId": 1000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_skyboxcm.exr.streamingimage"
+                            }
+                        }
+                    }
+                },
+                "Component_[1428633914413949476]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1428633914413949476
+                },
+                "Component_[14936200426671614999]": {
+                    "$type": "AZ::Render::EditorImageBasedLightComponent",
+                    "Id": 14936200426671614999,
+                    "Controller": {
+                        "Configuration": {
+                            "diffuseImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 3000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_ibldiffuse.exr.streamingimage"
+                            },
+                            "specularImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 2000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_iblspecular.exr.streamingimage"
+                            }
+                        }
+                    }
+                },
+                "Component_[14994774102579326069]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14994774102579326069
+                },
+                "Component_[15417479889044493340]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15417479889044493340
+                },
+                "Component_[15826613364991382688]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15826613364991382688
+                },
+                "Component_[1665003113283562343]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1665003113283562343
+                },
+                "Component_[3704934735944502280]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3704934735944502280
+                },
+                "Component_[5698542331457326479]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5698542331457326479
+                },
+                "Component_[6644513399057217122]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6644513399057217122,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[931091830724002070]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 931091830724002070
+                }
+            }
+        },
+        "Entity_[3211622250490]": {
+            "Id": "Entity_[3211622250490]",
+            "Name": "Universe",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 72537934025148840
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12186146815848538648
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17678288501376051163,
+                    "Child Entity Order": [
+                        "Instance_[2082921034728]/ContainerEntity"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654206021941863720
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15518960766143175381
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9816730482312148498
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 434450826752982482
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2388511220728113678
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 17007713375354418216,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "universe"
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16426579402129820987,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        }
+    },
+    "Instances": {
+        "Instance_[2082921034728]": {
+            "Source": "Prefabs/Cell.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[12382254012170911]/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
+                    "value": -6.959404945373535
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[12382254012170911]/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
+                    "value": 7.620587348937988
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[12382254012170911]/ContainerEntity/Components/TransformComponent/Transform Data/Translate/2",
+                    "value": 0.2500579357147217
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[1865420997526175]/ContainerEntity/Components/TransformComponent/Transform Data/Rotate/2",
+                    "value": 0.0
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2853434062950]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/loadBehavior",
+                    "value": "QueueLoad"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
+                    "value": "../Entity_[3211622250490]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2836254193766]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/loadBehavior",
+                    "value": "QueueLoad"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2771829684326]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/loadBehavior",
+                    "value": "QueueLoad"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2849139095654]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/loadBehavior",
+                    "value": "QueueLoad"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2801894455398]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/loadBehavior",
+                    "value": "QueueLoad"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2823369291878]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/loadBehavior",
+                    "value": "QueueLoad"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2814779357286]/Components/EditorArticulationLinkComponent/ArticulationConfiguration/Local Position/0",
+                    "value": -0.6439671516418457
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2814779357286]/Components/EditorArticulationLinkComponent/ArticulationConfiguration/Local Position/1",
+                    "value": -4.624497413635254
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2814779357286]/Components/EditorArticulationLinkComponent/ArticulationConfiguration/Local Position/2",
+                    "value": -3.766534805297851
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2814779357286]/Components/EditorArticulationLinkComponent/ArticulationConfiguration/Local Rotation/0",
+                    "value": 89.99996948242188
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2814779357286]/Components/EditorArticulationLinkComponent/ArticulationConfiguration/Local Rotation/1",
+                    "value": 89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2789009553510]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/loadBehavior",
+                    "value": "QueueLoad"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[317133007780767]/Entities/Entity_[2844844128358]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "value": true
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[381763642777368]/Components/EditorEntitySortComponent/Child Entity Order/8",
+                    "value": "Instance_[51574540204469]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[381763642777368]/Components/EditorEntitySortComponent/Child Entity Order/9",
+                    "value": "Instance_[51561655302581]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[381763642777368]/Components/ROS2FrameComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 8906912117127304616,
+                        "m_template": {
+                            "$type": "ROS2FrameComponent",
+                            "Id": 0,
+                            "Namespace Configuration": {
+                                "Namespace Strategy": 1,
+                                "Namespace": ""
+                            },
+                            "Frame Name": "objects",
+                            "Joint Name": "",
+                            "Publish Transform": true,
+                            "Force Dynamic": false
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[64332123955082]/Entities/Entity_[1189702382781087]/Components/EditorCylinderShapeComponent",
+                    "value": {
+                        "$type": "EditorCylinderShapeComponent",
+                        "Id": 4239868031923688940,
+                        "Visible": true,
+                        "GameView": false,
+                        "DisplayFilled": true,
+                        "ShapeColor": [
+                            1.0,
+                            1.0,
+                            0.7799999713897705,
+                            0.4000000059604645
+                        ],
+                        "CylinderShape": {
+                            "Configuration": {
+                                "DrawColor": [
+                                    1.0,
+                                    1.0,
+                                    0.7799999713897705,
+                                    0.4000000059604645
+                                ],
+                                "IsFilled": true,
+                                "Height": 1.0,
+                                "Radius": 0.5
+                            }
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[64332123955082]/Entities/Entity_[1189702382781087]/Components/ROS2FrameComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 4903743609518763740,
+                        "m_template": {
+                            "$type": "ROS2FrameComponent",
+                            "Id": 0,
+                            "Namespace Configuration": {
+                                "Namespace Strategy": 1,
+                                "Namespace": ""
+                            },
+                            "Frame Name": "table2",
+                            "Joint Name": "",
+                            "Publish Transform": true,
+                            "Force Dynamic": false
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[64332123955082]/Entities/Entity_[1189702382781087]/Components/ShapePublisherComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 16417183870646521853,
+                        "m_template": {
+                            "$type": "ShapePublisherComponent",
+                            "Id": 0,
+                            "ObjectName": "cylinder",
+                            "FrameId": "universe"
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[64250519576458]/Entities/Entity_[1121208881907]",
+                    "value": {
+                        "Id": "Entity_[1121208881907]",
+                        "Name": "secondShape",
+                        "Components": {
+                            "EditorBoxShapeComponent": {
+                                "$type": "EditorBoxShapeComponent",
+                                "Id": 3645648637610418793,
+                                "Visible": true,
+                                "GameView": false,
+                                "DisplayFilled": true,
+                                "ShapeColor": [
+                                    1.0,
+                                    1.0,
+                                    0.7799999713897705,
+                                    0.4000000059604645
+                                ],
+                                "BoxShape": {
+                                    "Configuration": {
+                                        "DrawColor": [
+                                            1.0,
+                                            1.0,
+                                            0.7799999713897705,
+                                            0.4000000059604645
+                                        ],
+                                        "IsFilled": true,
+                                        "Dimensions": [
+                                            1.0,
+                                            0.02693299949169159,
+                                            1.0
+                                        ],
+                                        "TranslationOffset": [
+                                            0.0,
+                                            0.6018993854522705,
+                                            0.0
+                                        ]
+                                    }
+                                },
+                                "ComponentMode": {}
+                            },
+                            "EditorDisabledCompositionComponent": {
+                                "$type": "EditorDisabledCompositionComponent",
+                                "Id": 10677013139391115649,
+                                "DisabledComponents": []
+                            },
+                            "EditorEntityIconComponent": {
+                                "$type": "EditorEntityIconComponent",
+                                "Id": 4990606102518919055,
+                                "EntityIconAssetId": {
+                                    "guid": "{00000000-0000-0000-0000-000000000000}",
+                                    "subId": 0
+                                }
+                            },
+                            "EditorEntitySortComponent": {
+                                "$type": "EditorEntitySortComponent",
+                                "Id": 5720232951344161260,
+                                "Child Entity Order": []
+                            },
+                            "EditorInspectorComponent": {
+                                "$type": "EditorInspectorComponent",
+                                "Id": 15820696501088996873,
+                                "ComponentOrderEntryArray": []
+                            },
+                            "EditorLockComponent": {
+                                "$type": "EditorLockComponent",
+                                "Id": 17629856383045088965,
+                                "Locked": false
+                            },
+                            "EditorOnlyEntityComponent": {
+                                "$type": "EditorOnlyEntityComponent",
+                                "Id": 1706458208239096886,
+                                "IsEditorOnly": false
+                            },
+                            "EditorPendingCompositionComponent": {
+                                "$type": "EditorPendingCompositionComponent",
+                                "Id": 5896418112064802111,
+                                "PendingComponents": []
+                            },
+                            "EditorVisibilityComponent": {
+                                "$type": "EditorVisibilityComponent",
+                                "Id": 5757532070126028783,
+                                "VisibilityFlag": true
+                            },
+                            "ROS2FrameComponent": {
+                                "$type": "GenericComponentWrapper",
+                                "Id": 15170148382072099051,
+                                "m_template": {
+                                    "$type": "ROS2FrameComponent",
+                                    "Id": 0,
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "table_1_frame_2",
+                                    "Joint Name": "",
+                                    "Publish Transform": true,
+                                    "Force Dynamic": false
+                                }
+                            },
+                            "ShapePublisherComponent": {
+                                "$type": "GenericComponentWrapper",
+                                "Id": 13843017156067656476,
+                                "m_template": {
+                                    "$type": "ShapePublisherComponent",
+                                    "Id": 0,
+                                    "ObjectName": "table1_b",
+                                    "FrameId": "universe"
+                                }
+                            },
+                            "TransformComponent": {
+                                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                                "Id": 9679335850594345445,
+                                "Parent Entity": "Entity_[1189702382781087]",
+                                "Transform Data": {
+                                    "Translate": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "Rotate": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "Scale": [
+                                        1.0,
+                                        1.0,
+                                        1.0
+                                    ],
+                                    "Locked": false,
+                                    "UniformScale": 1.0
+                                },
+                                "Parent Activation Transform Mode": 0,
+                                "IsStatic": false,
+                                "InterpolatePosition": 0,
+                                "InterpolateRotation": 0
+                            }
+                        },
+                        "IsRuntimeActive": true
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[7675426849712529]/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
+                    "value": -3.410111427307129
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[7675426849712529]/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
+                    "value": 7.770554542541504
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[7675426849712529]/ContainerEntity/Components/TransformComponent/Transform Data/Rotate/0",
+                    "value": 89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[7675426849712529]/ContainerEntity/Components/TransformComponent/Transform Data/Rotate/1",
+                    "value": -89.99990844726563
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[64250519576458]/Entities/Entity_[1189702382781087]/Components/EditorBoxShapeComponent",
+                    "value": {
+                        "$type": "EditorBoxShapeComponent",
+                        "Id": 9592227947965442616,
+                        "Visible": true,
+                        "GameView": false,
+                        "DisplayFilled": true,
+                        "ShapeColor": [
+                            1.0,
+                            1.0,
+                            0.7799999713897705,
+                            0.4000000059604645
+                        ],
+                        "BoxShape": {
+                            "Configuration": {
+                                "DrawColor": [
+                                    1.0,
+                                    1.0,
+                                    0.7799999713897705,
+                                    0.4000000059604645
+                                ],
+                                "IsFilled": true,
+                                "Dimensions": [
+                                    0.9595853090286256,
+                                    0.6109374165534973,
+                                    0.9638571739196776
+                                ],
+                                "TranslationOffset": [
+                                    0.0006024999893270433,
+                                    0.3016800880432129,
+                                    0.000539399974513799
+                                ]
+                            }
+                        },
+                        "ComponentMode": {}
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[64250519576458]/Entities/Entity_[1189702382781087]/Components/EditorEntitySortComponent/Child Entity Order/1",
+                    "value": "Entity_[1121208881907]"
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[64250519576458]/Entities/Entity_[1189702382781087]/Components/ROS2FrameComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 17107659219933132678,
+                        "m_template": {
+                            "$type": "ROS2FrameComponent",
+                            "Id": 0,
+                            "Namespace Configuration": {
+                                "Namespace Strategy": 0,
+                                "Namespace": ""
+                            },
+                            "Frame Name": "table_1_frame",
+                            "Joint Name": "",
+                            "Publish Transform": true,
+                            "Force Dynamic": false
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[64250519576458]/Entities/Entity_[1189702382781087]/Components/ShapePublisherComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 6271228036859219991,
+                        "m_template": {
+                            "$type": "ShapePublisherComponent",
+                            "Id": 0,
+                            "ObjectName": "table1_a"
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[7675426849712529]/Entities/Entity_[7675435439647121]/Components/EditorBoxShapeComponent",
+                    "value": {
+                        "$type": "EditorBoxShapeComponent",
+                        "Id": 4350001652332617412,
+                        "Visible": true,
+                        "GameView": false,
+                        "DisplayFilled": true,
+                        "ShapeColor": [
+                            1.0,
+                            1.0,
+                            0.7799999713897705,
+                            0.4000000059604645
+                        ],
+                        "BoxShape": {
+                            "Configuration": {
+                                "DrawColor": [
+                                    1.0,
+                                    1.0,
+                                    0.7799999713897705,
+                                    0.4000000059604645
+                                ],
+                                "IsFilled": true,
+                                "Dimensions": [
+                                    1.2000000476837158,
+                                    0.2199999988079071,
+                                    0.800000011920929
+                                ],
+                                "TranslationOffset": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ]
+                            }
+                        },
+                        "ComponentMode": {}
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[7675426849712529]/Entities/Entity_[7675435439647121]/Components/ROS2FrameComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 14587396376223461690,
+                        "m_template": {
+                            "$type": "ROS2FrameComponent",
+                            "Id": 0,
+                            "Namespace Configuration": {
+                                "Namespace Strategy": 0,
+                                "Namespace": ""
+                            },
+                            "Frame Name": "pallet_frame",
+                            "Joint Name": "",
+                            "Publish Transform": true,
+                            "Force Dynamic": false
+                        }
+                    }
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[7675426849712529]/Entities/Entity_[7675435439647121]/Components/ShapePublisherComponent",
+                    "value": {
+                        "$type": "GenericComponentWrapper",
+                        "Id": 8407197468352009994,
+                        "m_template": {
+                            "$type": "ShapePublisherComponent",
+                            "Id": 0,
+                            "ObjectName": "pallet"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/ros2_ws/src/ur_moveit_demo/src/mtc.cpp
+++ b/ros2_ws/src/ur_moveit_demo/src/mtc.cpp
@@ -375,7 +375,7 @@ mtc::Task MTCTaskNode::createTaskDrop(
         stage->allowCollisions(
             boxname, task.getRobotModel()->getJointModelGroup("ur_manipulator")->getLinkModelNamesWithCollisionGeometry(), false);
 
-        stage->addObject(CreateBoxCollision("pallet", PalletDimensions, fromMsg(palletPose.position), fromMsg(palletPose.orientation)));
+        // stage->addObject(CreateBoxCollision("pallet", PalletDimensions, fromMsg(palletPose.position), fromMsg(palletPose.orientation)));
         stage->allowCollisions(
             "pallet", task.getRobotModel()->getJointModelGroup("ur_manipulator")->getLinkModelNamesWithCollisionGeometry(), true);
         MoveToDrop->insert(std::move(stage));
@@ -643,8 +643,16 @@ int main(int argc, char** argv)
     }
     moveit_visual_tools.trigger();
 
+<<<<<<< HEAD
     planning_scene_interface.applyCollisionObject(
         CreateBoxCollision("pallet", PalletDimensions, fromMsg(palletPose.position), fromMsg(palletPose.orientation)));
+=======
+
+     }
+     moveit_visual_tools.trigger();
+
+    //  planning_scene_interface.applyCollisionObject(CreateBoxCollision("pallet", PalletDimensions, fromMsg(palletPose.position), fromMsg(palletPose.orientation)));
+>>>>>>> c918ab3 (pallet published from simulation)
 
     mtc_task_node->setupPlanningScene(node);
 

--- a/ros2_ws/src/ur_moveit_demo/src/mtc.cpp
+++ b/ros2_ws/src/ur_moveit_demo/src/mtc.cpp
@@ -618,13 +618,8 @@ int main(int argc, char** argv)
 
     // planning_scene_interface.applyCollisionObject(
     //     CreateBoxCollision("table", TableDimension, Eigen::Vector3d{ 0, 0, -TableDimension.z() / 2.0 }));
-<<<<<<< HEAD
-    planning_scene_interface.applyCollisionObject(
-        CreateBoxCollision("conveyor", ConveyorDimensions, Eigen::Vector3d{ ConveyorDimensions.x() / 2 + 0.75, -.5, -0.2 }));
-=======
     //  planning_scene_interface.applyCollisionObject(
     //      CreateBoxCollision("conveyor", ConveyorDimensions, Eigen::Vector3d{ ConveyorDimensions.x() / 2 + 0.75, -.5, -0.2 }));
->>>>>>> 97ce8c1 (table and conveyor published from simulation)
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     // find pallet pose
@@ -643,16 +638,8 @@ int main(int argc, char** argv)
     }
     moveit_visual_tools.trigger();
 
-<<<<<<< HEAD
-    planning_scene_interface.applyCollisionObject(
-        CreateBoxCollision("pallet", PalletDimensions, fromMsg(palletPose.position), fromMsg(palletPose.orientation)));
-=======
-
-     }
-     moveit_visual_tools.trigger();
-
-    //  planning_scene_interface.applyCollisionObject(CreateBoxCollision("pallet", PalletDimensions, fromMsg(palletPose.position), fromMsg(palletPose.orientation)));
->>>>>>> c918ab3 (pallet published from simulation)
+    // planning_scene_interface.applyCollisionObject(
+    //     CreateBoxCollision("pallet", PalletDimensions, fromMsg(palletPose.position), fromMsg(palletPose.orientation)));
 
     mtc_task_node->setupPlanningScene(node);
 

--- a/ros2_ws/src/ur_moveit_demo/src/mtc.cpp
+++ b/ros2_ws/src/ur_moveit_demo/src/mtc.cpp
@@ -36,8 +36,8 @@ bool SendGripperGrip(rclcpp_action::Client<control_msgs::action::GripperCommand>
 bool SendGripperrelease(rclcpp_action::Client<control_msgs::action::GripperCommand>::SharedPtr client_ptr);
 
 constexpr float BoxHeight = 0.3f;
-const Eigen::Vector3d TableDimension{ 0.950, 0.950, 0.411 };
-const Eigen::Vector3d ConveyorDimensions{ 2.0, 1., 0.15 };
+// const Eigen::Vector3d TableDimension{ 0.950, 0.950, 0.411 };
+// const Eigen::Vector3d ConveyorDimensions{ 2.0, 1., 0.15 };
 const Eigen::Vector3d PickupLocation{ 0.890, 0, 0.049 };
 const Eigen::Vector3d BoxDimension{ 0.2, 0.2, 0.2 };
 const Eigen::Vector3d PalletDimensions{ 1.2, 0.769, 0.111 };
@@ -618,8 +618,13 @@ int main(int argc, char** argv)
 
     // planning_scene_interface.applyCollisionObject(
     //     CreateBoxCollision("table", TableDimension, Eigen::Vector3d{ 0, 0, -TableDimension.z() / 2.0 }));
+<<<<<<< HEAD
     planning_scene_interface.applyCollisionObject(
         CreateBoxCollision("conveyor", ConveyorDimensions, Eigen::Vector3d{ ConveyorDimensions.x() / 2 + 0.75, -.5, -0.2 }));
+=======
+    //  planning_scene_interface.applyCollisionObject(
+    //      CreateBoxCollision("conveyor", ConveyorDimensions, Eigen::Vector3d{ ConveyorDimensions.x() / 2 + 0.75, -.5, -0.2 }));
+>>>>>>> 97ce8c1 (table and conveyor published from simulation)
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     // find pallet pose


### PR DESCRIPTION
This replaces manually set obstacles (table, pallet, conveyor) with those published by ShapePublisher.
Level single2_published_objects has ShapePublisher components attached to those objects - together with neccessary shapes and ros frames.


