### PR TITLE
Multiple lidars for collision detection

### DIFF
--- a/Project/Prefabs/OTTO600/OTTO600.prefab
+++ b/Project/Prefabs/OTTO600/OTTO600.prefab
@@ -90,7 +90,8 @@
                     "$type": "GenericComponentWrapper",
                     "Id": 1021054117381513344,
                     "m_template": {
-                        "$type": "ROS2FrameComponent"
+                        "$type": "ROS2FrameComponent",
+                        "Frame Name": "sensor_frame_front"
                     }
                 },
                 "ROS2Lidar2DSensorComponent": {
@@ -102,7 +103,7 @@
                             "Publishers": {
                                 "sensor_msgs::msg::LaserScan": {
                                     "Type": "sensor_msgs::msg::LaserScan",
-                                    "Topic": "ls"
+                                    "Topic": "scan_front"
                                 }
                             }
                         },
@@ -167,7 +168,8 @@
                     "$type": "GenericComponentWrapper",
                     "Id": 1021054117381513344,
                     "m_template": {
-                        "$type": "ROS2FrameComponent"
+                        "$type": "ROS2FrameComponent",
+                        "Frame Name": "sensor_frame_rear"
                     }
                 },
                 "ROS2Lidar2DSensorComponent": {
@@ -179,7 +181,7 @@
                             "Publishers": {
                                 "sensor_msgs::msg::LaserScan": {
                                     "Type": "sensor_msgs::msg::LaserScan",
-                                    "Topic": "ls"
+                                    "Topic": "scan_rear"
                                 }
                             }
                         },

--- a/ros2_ws/src/o3de_fleet_nav/params/humble/nav2_multirobot_params.yaml
+++ b/ros2_ws/src/o3de_fleet_nav/params/humble/nav2_multirobot_params.yaml
@@ -204,9 +204,19 @@ local_costmap:
         z_voxels: 16
         max_obstacle_height: 2.0
         mark_threshold: 0
-        observation_sources: scan
-        scan:
-          topic: /<robot_namespace>/scan
+        observation_sources: scan_front scan_rear
+        scan_front:
+          topic: /<robot_namespace>/scan_front
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+        scan_rear:
+          topic: /<robot_namespace>/scan_rear
           max_obstacle_height: 2.0
           clearing: True
           marking: True
@@ -231,9 +241,19 @@ global_costmap:
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
-        observation_sources: scan
-        scan:
-          topic: /<robot_namespace>/scan
+        observation_sources: scan_front scan_rear
+        scan_front:
+          topic: /<robot_namespace>/scan_front
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+        scan_rear:
+          topic: /<robot_namespace>/scan_rear
           max_obstacle_height: 2.0
           clearing: True
           marking: True


### PR DESCRIPTION
Added configuration for two lidars publishing on scan_front and scan_rear.
Modified prefab to make the frames and topics of lidars unique.