### PR TITLE
Add ebus for ideal vision system

### DIFF
--- a/Project/Gem/Include/Vision/IdealVisionSystemBus.h
+++ b/Project/Gem/Include/Vision/IdealVisionSystemBus.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root
+ * of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/EBus/Policies.h>
+
+namespace ROS2::Demo
+{
+    class IdealVisionSystemNotification : public AZ::ComponentBus
+    {
+    public:
+        using BusIdType = AZ::EntityId;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+
+        virtual void OnObjectsDetected(AZStd::vector<AZ::EntityId> detectedObjects) = 0;
+    };
+
+    using IdealVisionSystemNotificationBus = AZ::EBus<IdealVisionSystemNotification>;
+
+} // namespace ROS2::Demo

--- a/Project/Gem/ROSCon2023Demo_files.cmake
+++ b/Project/Gem/ROSCon2023Demo_files.cmake
@@ -22,5 +22,6 @@ set(FILES
     Source/Vision/IdealVisionSystem.h
     Source/Vision/IdealVisionSystemConfiguration.cpp
     Source/Vision/IdealVisionSystemConfiguration.h
+    Include/Vision/IdealVisionSystemBus.h
     enabled_gems.cmake
 )

--- a/Project/Gem/Source/Vision/IdealVisionSystem.h
+++ b/Project/Gem/Source/Vision/IdealVisionSystem.h
@@ -10,6 +10,7 @@
 
 #include "IdealVisionSystemConfiguration.h"
 #include <AzCore/Component/Component.h>
+#include <AzCore/Component/EntityId.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/std/containers/unordered_set.h>
@@ -17,6 +18,7 @@
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <ROS2/Camera/CameraCalibrationRequestBus.h>
 #include <ROS2/Sensor/ROS2SensorComponent.h>
+#include <Vision/IdealVisionSystemBus.h>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <rclcpp/publisher.hpp>
 #include <vision_msgs/msg/detection2_d_array.hpp>


### PR DESCRIPTION
I've added an EBus to the ideal vision system, so that other components can be notified of present objects in the view of the camera. 