### PR TITLE
Add missing install directive

### DIFF
--- a/ros2_ws/src/otto_deliberation/CMakeLists.txt
+++ b/ros2_ws/src/otto_deliberation/CMakeLists.txt
@@ -30,6 +30,8 @@ ament_target_dependencies(
 install(TARGETS deliberation_otto_node
         DESTINATION lib/${PROJECT_NAME})
 
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+
 if (BUILD_TESTING)
     find_package(ament_lint_auto REQUIRED)
     # the following line skips the linter which checks for copyrights


### PR DESCRIPTION
I've added a missing install directive in otto_deliberation that installs the launch file.
Fixes: #116 