### PR TITLE
Locking orchestration

### DIFF
--- a/ros2_ws/src/demo_orchestration/CMakeLists.txt
+++ b/ros2_ws/src/demo_orchestration/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package (Eigen3 3.3 REQUIRED)
+find_package(lock_service_msgs REQUIRED)
+find_package(lane_provider_msgs REQUIRED)
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
@@ -27,6 +29,8 @@ $<INSTALL_INTERFACE:include>)
 ament_target_dependencies(
   demo_orchestration
   ur_moveit_demo_msg
+  lock_service_msgs
+  lane_provider_msgs
   "rclcpp"
   "tf2_msgs"
   "tf2_ros"

--- a/ros2_ws/src/demo_orchestration/include/demo_orchestration/mtc_action_client.h
+++ b/ros2_ws/src/demo_orchestration/include/demo_orchestration/mtc_action_client.h
@@ -1,0 +1,14 @@
+#include <nav2_msgs/action/detail/navigate_through_poses__struct.hpp>
+#include <nav2_msgs/action/navigate_through_poses.hpp>
+#include <nav2_msgs/action/navigate_to_pose.hpp>
+#include <rclcpp_action/create_client.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <ur_moveit_demo_msg/action/follow_path.hpp>
+#include <ur_moveit_demo_msg/action/mtc.hpp>
+#include <functional>
+
+class MTCActionClient {
+    using ResultCallback = std::function<void(bool)>;
+	using MTCAction = ur_moveit_demo_msg::action::Mtc;
+	using GoalHandleMTC = rclcpp_action::ClientGoalHandle<MTCAction>; 
+}

--- a/ros2_ws/src/demo_orchestration/launch/orchestration.launch.py
+++ b/ros2_ws/src/demo_orchestration/launch/orchestration.launch.py
@@ -9,37 +9,13 @@ from launch.substitutions import LaunchConfiguration
 
 def launch_setup(context, *args, **kwargs):
 
-    ur_namespace = LaunchConfiguration("ur_namespace")
-    amr_namespaces = LaunchConfiguration("amr_namespaces")
-    num_of_boxes = LaunchConfiguration("number_of_boxes")
-    path_namespace = LaunchConfiguration("path_namespace")
-
     nodes_to_start = []
-
-    for x in amr_namespaces.perform(context).strip('][').split(', '):
-        nodes_to_start.append(Node(
-            name="pathFollower",
-            package="demo_orchestration",
-            executable="path_follower",
-            output="screen",
-            parameters=[
-                {"use_sim_time": True},
-                {"ns": x},
-            ],
-        ))
 
     orchestration = Node(
         name="orchestration",
         package="demo_orchestration",
         executable="demo_orchestration",
         output="screen",
-        parameters=[
-            {"use_sim_time": True},
-            {"ur_namespace": ur_namespace},
-            {"amr_namespaces": amr_namespaces},
-            {"number_of_boxes": num_of_boxes},
-            {"path_namespace": path_namespace}
-        ],
     )
 
     nodes_to_start.append(orchestration)
@@ -51,37 +27,5 @@ def launch_setup(context, *args, **kwargs):
 def generate_launch_description():
 
     declared_arguments = []
-
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "ur_namespace",
-            default_value='""',
-            description="Namespace for the robot arm, useful for running multiple instances.",
-        )
-    )
-
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "amr_namespaces",
-            default_value=[],
-            description="Namespace for the amr, useful for running multiple instances.",
-        )
-    )
-
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "path_namespace",
-            default_value='""',
-            description="Namespace for the paths for the AMRs",
-        )
-    )
-
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "number_of_boxes",
-            default_value='""',
-            description="Number of boxes to be placed on the pallet",
-        )
-    )
 
     return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])

--- a/ros2_ws/src/demo_orchestration/src/demo_orchestration.cpp
+++ b/ros2_ws/src/demo_orchestration/src/demo_orchestration.cpp
@@ -1,540 +1,152 @@
-
-#include <chrono>
 #include <functional>
-#include <geometry_msgs/msg/detail/pose_stamped__struct.hpp>
-#include <geometry_msgs/msg/pose_stamped.hpp>
-#include <memory>
-#include <mutex>
-#include <nav2_msgs/action/detail/navigate_through_poses__struct.hpp>
-#include <nav2_msgs/action/navigate_through_poses.hpp>
-#include <nav2_msgs/action/navigate_to_pose.hpp>
-#include <nav_msgs/msg/detail/path__struct.hpp>
-#include <nav_msgs/msg/path.hpp>
+#include <lane_provider_msgs/srv/list_tracks.hpp>
+#include <lock_service_msgs/srv/detail/lock__struct.hpp>
+#include <lock_service_msgs/srv/lock.hpp>
+#include <rclcpp/executors.hpp>
 #include <rclcpp/node.hpp>
-#include <rclcpp/publisher.hpp>
-#include <rclcpp/qos.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <rclcpp_action/create_client.hpp>
-#include <rclcpp_action/rclcpp_action.hpp>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
-#include <thread>
-#include <ur_moveit_demo_msg/action/detail/follow_path__struct.hpp>
-#include <vector>
+#include <rclcpp/utilities.hpp>
+#include <string>
 
-#include "ur_moveit_demo_msg/action/mtc.hpp"
-
-int num_of_boxes;
-std::string path_namespace;
-
-enum AMRState
+class LockService
 {
-    MovingToPickup,
-    Approach,
-    MovingApproach,
-    Departure,
-    MovingDeparture,
-    MovingToDrop,
-    MovingToPark,
-    Drop,
-    Pickup,
-    Park,
-};
+    using PathLocks = std::map<std::string, bool>;
 
-enum MoveItState
-{
-    Load,
-    Ready,
-    AfterLoad,
-    BeforeLoad,
-};
-
-class FollowPathActionClient
-{
 public:
-    using FollowPathAction = ur_moveit_demo_msg::action::FollowPath;
-    using GoalHandleFollowPath = rclcpp_action::ClientGoalHandle<FollowPathAction>;
-
-    FollowPathActionClient(rclcpp::Node::SharedPtr node, std::string ns)
-        : node_(node)
+    LockService(rclcpp::Node::SharedPtr node)
+        : m_node(node)
     {
-        this->client_ptr_ = rclcpp_action::create_client<FollowPathAction>(node_, "/" + ns + "/follow_path");
-    }
+        m_service = node->create_service<lock_service_msgs::srv::Lock>(
+            "/lock_service", std::bind(&LockService::LockSrv, this, std::placeholders::_1, std::placeholders::_2));
+    };
 
-    void send_goal(float speed, bool reverse, std::vector<geometry_msgs::msg::PoseStamped> poses, std::function<void()> callback)
+    void LockSrv(
+        const std::shared_ptr<lock_service_msgs::srv::Lock::Request> request,
+        std::shared_ptr<lock_service_msgs::srv::Lock::Response> response)
     {
-        using namespace std::placeholders;
-
-        if (!this->client_ptr_->wait_for_action_server())
+        if (request->lock_status == true)
         {
-            RCLCPP_ERROR(node_->get_logger(), "Action server not available after waiting");
-            rclcpp::shutdown();
-        }
-
-        auto goal_msg = FollowPathAction::Goal();
-        goal_msg.speed = speed;
-        goal_msg.reverse = reverse;
-        goal_msg.poses = poses;
-
-        RCLCPP_INFO(node_->get_logger(), "Sending goal");
-
-        auto send_goal_options = rclcpp_action::Client<FollowPathAction>::SendGoalOptions();
-        send_goal_options.goal_response_callback = std::bind(&FollowPathActionClient::goal_response_callback, this, _1);
-        send_goal_options.feedback_callback = std::bind(&FollowPathActionClient::feedback_callback, this, _1, _2);
-        send_goal_options.result_callback = std::bind(&FollowPathActionClient::result_callback, this, _1);
-        this->client_ptr_->async_send_goal(goal_msg, send_goal_options);
-
-        m_resultCallback = callback;
-    }
-
-private:
-    rclcpp_action::Client<FollowPathAction>::SharedPtr client_ptr_;
-    rclcpp::TimerBase::SharedPtr timer_;
-    rclcpp::Node::SharedPtr node_;
-
-    std::function<void()> m_resultCallback;
-
-    void goal_response_callback(std::shared_ptr<rclcpp_action::ClientGoalHandle<ur_moveit_demo_msg::action::FollowPath>> future)
-    {
-        auto goal_handle = future.get();
-        if (!goal_handle)
-        {
-            RCLCPP_ERROR(node_->get_logger(), "Goal was rejected by server");
+            bool isLocked = IsPathLocked(request->lane_name, request->path_name);
+            if (!isLocked)
+            {
+                SetPathLock(request->lane_name, request->path_name, true);
+            }
+            response->result = !isLocked;
         }
         else
         {
-            RCLCPP_INFO(node_->get_logger(), "Goal accepted by server, waiting for result");
+            SetPathLock(request->lane_name, request->path_name, false);
+            response->result = true;
         }
-    }
+    };
 
-    void feedback_callback(GoalHandleFollowPath::SharedPtr, const std::shared_ptr<const FollowPathAction::Feedback> feedback)
+    bool Initialize()
     {
-    }
-
-    void result_callback(const GoalHandleFollowPath::WrappedResult& result)
-    {
-        m_resultCallback();
-        switch (result.code)
+        std::string lane_track_service = m_node->declare_parameter<std::string>("lane_track_service", "/get_lanes_and_paths");
+        m_node->get_parameter<std::string>("lane_track_service", lane_track_service);
+        auto laneTracksClient = m_node->create_client<lane_provider_msgs::srv::ListTracks>(lane_track_service);
+        if (!laneTracksClient->wait_for_service(std::chrono::seconds(2)))
         {
-        case rclcpp_action::ResultCode::SUCCEEDED:
-            break;
-        case rclcpp_action::ResultCode::ABORTED:
-            RCLCPP_ERROR(node_->get_logger(), "Goal was aborted");
-            return;
-        case rclcpp_action::ResultCode::CANCELED:
-            RCLCPP_ERROR(node_->get_logger(), "Goal was canceled");
-            return;
-        default:
-            RCLCPP_ERROR(node_->get_logger(), "Unknown result code");
-            return;
+            RCLCPP_ERROR(m_node->get_logger(), "Lane track service named %s not available", lane_track_service.c_str());
+            return false;
         }
-        std::stringstream ss;
-        ss << "Result received: ";
 
-        ss << result.result->success << " ";
-
-        RCLCPP_INFO(node_->get_logger(), ss.str().c_str());
-    }
-}; // class MTCActionClient
-
-class MTCActionClient
-{
-public:
-    using MTCAction = ur_moveit_demo_msg::action::Mtc;
-    using GoalHandleMTC = rclcpp_action::ClientGoalHandle<MTCAction>;
-
-    MTCActionClient(rclcpp::Node::SharedPtr node, std::string ur_namespace)
-        : node_(node)
-    {
-        this->client_ptr_ = rclcpp_action::create_client<MTCAction>(node_, "/" + ur_namespace + "/MTC");
-    }
-
-    void send_goal(int number_of_boxes, std::function<void()> callback)
-    {
-        using namespace std::placeholders;
-
-        if (!this->client_ptr_->wait_for_action_server())
+        auto lane_request = std::make_shared<lane_provider_msgs::srv::ListTracks::Request>();
+        auto lane_track_response_future = laneTracksClient->async_send_request(lane_request);
+        if (rclcpp::spin_until_future_complete(m_node, lane_track_response_future) != rclcpp::FutureReturnCode::SUCCESS)
         {
-            RCLCPP_ERROR(node_->get_logger(), "Action server not available after waiting");
-            rclcpp::shutdown();
+            RCLCPP_ERROR(m_node->get_logger(), "Failed to call service %s", lane_track_service.c_str());
+            return false;
         }
 
-        auto goal_msg = MTCAction::Goal();
-        goal_msg.num_of_boxes = number_of_boxes;
-
-        RCLCPP_INFO(node_->get_logger(), "Sending goal");
-
-        auto send_goal_options = rclcpp_action::Client<MTCAction>::SendGoalOptions();
-        send_goal_options.goal_response_callback = std::bind(&MTCActionClient::goal_response_callback, this, _1);
-        send_goal_options.feedback_callback = std::bind(&MTCActionClient::feedback_callback, this, _1, _2);
-        send_goal_options.result_callback = std::bind(&MTCActionClient::result_callback, this, _1);
-        this->client_ptr_->async_send_goal(goal_msg, send_goal_options);
-
-        m_resultCallback = callback;
+        auto allLanes = lane_track_response_future.get();
+        for (auto lane : allLanes->lane_paths)
+        {
+            PathLocks locks;
+            for (auto path : lane.path_names)
+            {
+                locks.insert({ path, false });
+            }
+            m_lanesLocks.insert({ lane.lane_name, locks });
+        }
+        return true;
     }
 
 private:
-    rclcpp_action::Client<MTCAction>::SharedPtr client_ptr_;
-    rclcpp::TimerBase::SharedPtr timer_;
-    rclcpp::Node::SharedPtr node_;
+    rclcpp::Node::SharedPtr m_node;
 
-    std::function<void()> m_resultCallback;
+    std::map<std::string, PathLocks> m_lanesLocks;
 
-    void goal_response_callback(std::shared_ptr<rclcpp_action::ClientGoalHandle<ur_moveit_demo_msg::action::Mtc>> future)
+    rclcpp::Service<lock_service_msgs::srv::Lock>::SharedPtr m_service;
+
+    std::optional<std::string> PathDependency(const std::string& path_name)
     {
-        auto goal_handle = future.get();
-        if (!goal_handle)
+        static const std::map<std::string, std::string> dependencies = { { "GoToPickup", "ApproachPickup" },
+                                                                         { "ApproachPickup", "EvacuateFromPickup" } };
+
+        if (dependencies.find(path_name) == dependencies.end())
         {
-            RCLCPP_ERROR(node_->get_logger(), "Goal was rejected by server");
+            return std::optional<std::string>();
         }
-        else
+        return std::optional<std::string>(dependencies.find(path_name)->second);
+    };
+
+    bool IsPathGlobal(const std::string& path_name)
+    {
+        static const std::set<std::string> globalPaths = {};
+        return globalPaths.count(path_name) == 1;
+    };
+
+    bool IsPathLocked(const std::string& lane_name, std::string path_name)
+    {
+        bool isLocked = false;
+        if (IsPathGlobal(path_name))
         {
-            RCLCPP_INFO(node_->get_logger(), "Goal accepted by server, waiting for result");
-        }
-    }
-
-    void feedback_callback(GoalHandleMTC::SharedPtr, const std::shared_ptr<const MTCAction::Feedback> feedback)
-    {
-        std::stringstream ss;
-        ss << "Placed box number: ";
-        ss << feedback->current_box << " ";
-
-        RCLCPP_INFO(node_->get_logger(), ss.str().c_str());
-    }
-
-    void result_callback(const GoalHandleMTC::WrappedResult& result)
-    {
-        m_resultCallback();
-        switch (result.code)
-        {
-        case rclcpp_action::ResultCode::SUCCEEDED:
-            break;
-        case rclcpp_action::ResultCode::ABORTED:
-            RCLCPP_ERROR(node_->get_logger(), "Goal was aborted");
-            return;
-        case rclcpp_action::ResultCode::CANCELED:
-            RCLCPP_ERROR(node_->get_logger(), "Goal was canceled");
-            return;
-        default:
-            RCLCPP_ERROR(node_->get_logger(), "Unknown result code");
-            return;
-        }
-        std::stringstream ss;
-        ss << "Result received: ";
-
-        ss << result.result->success << " ";
-
-        RCLCPP_INFO(node_->get_logger(), ss.str().c_str());
-    }
-}; // class MTCActionClient
-
-class Nav2ActionClient
-{
-public:
-    using Nav2Action = nav2_msgs::action::NavigateThroughPoses;
-    using GoalHandleNav2 = rclcpp_action::ClientGoalHandle<Nav2Action>;
-
-    Nav2ActionClient(rclcpp::Node::SharedPtr node, std::string amr_ns)
-        : node_(node)
-    {
-        this->client_ptr_ = rclcpp_action::create_client<Nav2Action>(node_, "/" + amr_ns + "/navigate_through_poses");
-    }
-
-    void send_goal(nav_msgs::msg::Path targetPath, std::function<void()> callback)
-    {
-        m_resultCallback = callback;
-
-        using namespace std::placeholders;
-
-        if (!this->client_ptr_->wait_for_action_server())
-        {
-            RCLCPP_ERROR(node_->get_logger(), "Action server not available after waiting");
-            rclcpp::shutdown();
-        }
-
-        auto goal_msg = Nav2Action::Goal();
-
-        std::shared_ptr<tf2_ros::TransformListener> tf_listener_{ nullptr };
-        std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
-
-        goal_msg.poses = targetPath.poses;
-
-        RCLCPP_INFO(node_->get_logger(), "Sending goal");
-
-        auto send_goal_options = rclcpp_action::Client<Nav2Action>::SendGoalOptions();
-        send_goal_options.goal_response_callback = std::bind(&Nav2ActionClient::goal_response_callback, this, _1);
-        send_goal_options.feedback_callback = std::bind(&Nav2ActionClient::feedback_callback, this, _1, _2);
-        send_goal_options.result_callback = std::bind(&Nav2ActionClient::result_callback, this, _1);
-        this->client_ptr_->async_send_goal(goal_msg, send_goal_options);
-    }
-
-private:
-    rclcpp_action::Client<Nav2Action>::SharedPtr client_ptr_;
-    rclcpp::TimerBase::SharedPtr timer_;
-    rclcpp::Node::SharedPtr node_;
-
-    std::function<void()> m_resultCallback;
-
-    void goal_response_callback(std::shared_ptr<rclcpp_action::ClientGoalHandle<nav2_msgs::action::NavigateThroughPoses>> future)
-    {
-        auto goal_handle = future.get();
-        if (!goal_handle)
-        {
-            RCLCPP_ERROR(node_->get_logger(), "Goal was rejected by server");
-        }
-        else
-        {
-            RCLCPP_INFO(node_->get_logger(), "Goal accepted by server, waiting for result");
-        }
-    }
-
-    void feedback_callback(GoalHandleNav2::SharedPtr, const std::shared_ptr<const GoalHandleNav2::Feedback> feedback)
-    {
-    }
-
-    void result_callback(const GoalHandleNav2::WrappedResult& result)
-    {
-        m_resultCallback();
-        switch (result.code)
-        {
-        case rclcpp_action::ResultCode::SUCCEEDED:
-            break;
-        case rclcpp_action::ResultCode::ABORTED:
-            RCLCPP_ERROR(node_->get_logger(), "Goal nav was aborted");
-            return;
-        case rclcpp_action::ResultCode::CANCELED:
-            RCLCPP_ERROR(node_->get_logger(), "Goal was canceled");
-            return;
-        default:
-            RCLCPP_ERROR(node_->get_logger(), "Unknown result code");
-            return;
-        }
-    }
-};
-
-geometry_msgs::msg::PoseStamped TransformToPose(geometry_msgs::msg::TransformStamped transform)
-{
-    geometry_msgs::msg::PoseStamped result;
-    result.pose.position.set__x(transform.transform.translation.x)
-        .set__y(transform.transform.translation.y)
-        .set__z(transform.transform.translation.y);
-    result.header.frame_id = transform.header.frame_id;
-    result.pose.orientation.set__w(transform.transform.rotation.w)
-        .set__x(transform.transform.rotation.x)
-        .set__y(transform.transform.rotation.y)
-        .set__z(transform.transform.rotation.z);
-
-    return result;
-}
-
-struct AMRController
-{
-    AMRState state;
-    std::shared_ptr<Nav2ActionClient> client;
-    std::shared_ptr<FollowPathActionClient> followPathClient;
-    std::string amrNamespace;
-};
-
-struct MoveItController
-{
-    MoveItState state;
-    std::shared_ptr<MTCActionClient> client;
-};
-
-class StationOrchestrator
-{
-public:
-    StationOrchestrator(rclcpp::Node::SharedPtr node, std::string moveItNamespace, std::vector<std::string> amrNamespaces)
-    {
-        m_moveItController = {
-            MoveItState::Ready,
-            std::make_shared<MTCActionClient>(node, moveItNamespace),
-        };
-        for (auto amrNamespace : amrNamespaces)
-        {
-            m_amrControllers.push_back({
-                AMRState::Park,
-                std::make_shared<Nav2ActionClient>(node, amrNamespace),
-                std::make_shared<FollowPathActionClient>(node, amrNamespace),
-                amrNamespace,
-            });
-        }
-
-        rclcpp::QoS qos(5);
-        qos.transient_local();
-
-        auto pickupPathSubscriber = node->create_subscription<nav_msgs::msg::Path>(
-            path_namespace + "/pickupPath",
-            qos,
-            [&](nav_msgs::msg::Path path)
+            for (auto paths : m_lanesLocks)
             {
-                m_pickupPath = path;
-            });
-
-        auto parkSubscriber = node->create_subscription<nav_msgs::msg::Path>(
-            path_namespace + "/parkPath",
-            qos,
-            [&](nav_msgs::msg::Path path)
-            {
-                m_parkPath = path;
-            });
-
-        auto dropSubscriber = node->create_subscription<nav_msgs::msg::Path>(
-            path_namespace + "/dropPath",
-            qos,
-            [&](nav_msgs::msg::Path path)
-            {
-                m_dropPath = path;
-            });
-
-        auto approachSubscriber = node->create_subscription<nav_msgs::msg::Path>(
-            path_namespace + "/approachPath",
-            qos,
-            [&](nav_msgs::msg::Path path)
-            {
-                m_approachPath = path;
-            });
-
-        auto departureSubscriber = node->create_subscription<nav_msgs::msg::Path>(
-            path_namespace + "/departurePath",
-            qos,
-            [&](nav_msgs::msg::Path path)
-            {
-                m_departurePath = path;
-            });
-
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-
-    void start()
-    {
-        std::thread runner(
-            [&]()
-            {
-                while (true)
+                auto lockIterator = paths.second.find(path_name);
+                if (lockIterator != paths.second.end())
                 {
-                    {
-                        std::lock_guard<std::mutex> notifyLock(m_notifyLock);
-                        for (std::vector<AMRController>::size_type i = 0; i < m_amrControllers.size(); i++)
-                        {
-                            auto& m_amrController = m_amrControllers[i];
-                            if (m_amrController.state == AMRState::Drop)
-                            {
-                                m_amrController.state = AMRState::MovingToPark;
-                                auto boundFn =
-                                    std::bind(&StationOrchestrator::notifyAMR, this, AMRState::Park, m_amrController.amrNamespace);
-                                m_amrController.client->send_goal(
-                                    m_parkPath,
-                                    std::bind(&StationOrchestrator::notifyAMR, this, AMRState::Park, m_amrController.amrNamespace));
-                            }
-                            if (m_amrController.state == AMRState::Approach)
-                            {
-                                m_amrController.state = AMRState::MovingApproach;
-                                m_amrController.followPathClient->send_goal(
-                                    0.1,
-                                    false,
-                                    m_approachPath.poses,
-                                    std::bind(&StationOrchestrator::notifyAMR, this, AMRState::Pickup, m_amrController.amrNamespace));
-                            }
-                            if (m_amrController.state == AMRState::Departure)
-                            {
-                                m_amrController.state = AMRState::MovingToDrop;
-                                m_moveItController.state = MoveItState::Ready;
-                                m_amrController.client->send_goal(
-                                    m_dropPath,
-                                    std::bind(&StationOrchestrator::notifyAMR, this, AMRState::Drop, m_amrController.amrNamespace));
-                            }
-                        }
-                        if (m_moveItController.state == MoveItState::BeforeLoad)
-                        {
-                            for (std::vector<AMRController>::size_type i = 0; i < m_amrControllers.size(); i++)
-                            {
-                                auto& m_amrController = m_amrControllers[i];
-                                if (m_amrController.state == AMRState::Pickup)
-                                {
-                                    m_moveItController.state = MoveItState::Load;
-                                    // m_amrController.client->send_goal(
-                                    //     m_posePickup,
-                                    //     std::bind(&StationOrchestrator::notifyAMR, this, AMRState::Pickup, m_amrController.amrNamespace));
-                                    m_moveItController.client->send_goal(num_of_boxes, std::bind(&StationOrchestrator::notifyMoveIt, this, MoveItState::AfterLoad));
-                                    break;
-                                }
-                            }
-                        }
-                        if (m_moveItController.state == MoveItState::AfterLoad)
-                        {
-                            for (std::vector<AMRController>::size_type i = 0; i < m_amrControllers.size(); i++)
-                            {
-                                auto& m_amrController = m_amrControllers[i];
-                                if (m_amrController.state == AMRState::Pickup)
-                                {
-                                    m_amrController.state = AMRState::MovingDeparture;
-                                    m_amrController.followPathClient->send_goal(
-                                        0.1,
-                                        true,
-                                        m_departurePath.poses,
-                                        std::bind(
-                                            &StationOrchestrator::notifyAMR, this, AMRState::Departure, m_amrController.amrNamespace));
-                                    break;
-                                }
-                            }
-                        }
-                        if (m_moveItController.state == MoveItState::Ready)
-                        {
-                            for (std::vector<AMRController>::size_type i = 0; i < m_amrControllers.size(); i++)
-                            {
-                                auto& m_amrController = m_amrControllers[i];
-                                if (m_amrController.state == AMRState::Park)
-                                {
-                                    m_amrController.state = AMRState::MovingToPickup;
-                                    m_moveItController.state = MoveItState::BeforeLoad;
-                                    m_amrController.client->send_goal(
-                                        m_pickupPath,
-                                        std::bind(&StationOrchestrator::notifyAMR, this, AMRState::Approach, m_amrController.amrNamespace));
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
-                    m_lock.lock();
+                    isLocked |= lockIterator->second;
                 }
-            });
-        runner.join();
-    }
-
-    void notifyAMR(AMRState amrState, std::string amrNamespace)
-    {
-        std::lock_guard<std::mutex> lock(m_notifyLock);
-        for (std::vector<AMRController>::size_type i = 0; i < m_amrControllers.size(); i++)
-        {
-            if (m_amrControllers[i].amrNamespace == amrNamespace)
-            {
-                m_amrControllers[i].state = amrState;
             }
         }
-        m_lock.unlock();
+        else
+        {
+            auto paths = m_lanesLocks.find(lane_name);
+            if (paths == m_lanesLocks.end())
+            {
+                return false;
+            }
+            auto pathIterator = paths->second.find(path_name);
+            if (pathIterator == paths->second.end())
+            {
+                return false;
+            }
+            isLocked |= pathIterator->second;
+        }
+        auto pathDependency = PathDependency(path_name);
+        if (!isLocked && pathDependency)
+        {
+            isLocked |= IsPathLocked(lane_name, *pathDependency);
+        }
+        return isLocked;
     }
 
-    void notifyMoveIt(MoveItState moveItState)
+    void SetPathLock(const std::string& lane_name, std::string path_name, bool lock)
     {
-        std::lock_guard<std::mutex> lock(m_notifyLock);
-        m_moveItController.state = moveItState;
-        m_lock.unlock();
+        auto pathsIterator = m_lanesLocks.find(lane_name);
+        if (pathsIterator == m_lanesLocks.end())
+        {
+            return;
+        }
+        auto pathLockIterator = pathsIterator->second.find(path_name);
+        if (pathLockIterator == pathsIterator->second.end())
+        {
+            return;
+        }
+        pathLockIterator->second = lock;
     }
-
-private:
-    MoveItController m_moveItController;
-    std::vector<AMRController> m_amrControllers;
-
-    nav_msgs::msg::Path m_pickupPath;
-    nav_msgs::msg::Path m_dropPath;
-    nav_msgs::msg::Path m_parkPath;
-    nav_msgs::msg::Path m_approachPath;
-    nav_msgs::msg::Path m_departurePath;
-
-    std::mutex m_lock;
-    std::mutex m_notifyLock;
 };
 
 int main(int argc, char** argv)
@@ -545,28 +157,13 @@ int main(int argc, char** argv)
     options.automatically_declare_parameters_from_overrides(true);
 
     auto const node =
-        std::make_shared<rclcpp::Node>("demo_orchestration", rclcpp::NodeOptions().automatically_declare_parameters_from_overrides(true));
+        std::make_shared<rclcpp::Node>("orchestrator", rclcpp::NodeOptions().automatically_declare_parameters_from_overrides(true));
 
-    rclcpp::executors::SingleThreadedExecutor executor;
-    executor.add_node(node);
-    auto spinner = std::thread(
-        [&executor]()
-        {
-            executor.spin();
-        });
+    LockService lockService(node);
+    lockService.Initialize();
 
-    auto ur_ns = node->get_parameter("ur_namespace").as_string();
-    auto amr_namespaces = node->get_parameter("amr_namespaces").as_string_array();
-    num_of_boxes = node->get_parameter("number_of_boxes").as_int();
-    path_namespace = node->get_parameter("path_namespace").as_string();
-    if (!path_namespace.empty())
-    {
-        path_namespace = "/" + path_namespace;
-    }
-
-    StationOrchestrator stationOrchestrator(node, ur_ns, amr_namespaces);
-    stationOrchestrator.start();
-    spinner.join();
+    rclcpp::spin(node);
     rclcpp::shutdown();
+
     return 0;
 }

--- a/ros2_ws/src/lock_service_msgs/CMakeLists.txt
+++ b/ros2_ws/src/lock_service_msgs/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.8)
+project(lock_service_msgs)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/Lock.srv"
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/ros2_ws/src/lock_service_msgs/package.xml
+++ b/ros2_ws/src/lock_service_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>demo_orchestration</name>
+  <name>lock_service_msgs</name>
   <version>0.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="artur.kamieniecki@robotec.ai">artur</maintainer>
@@ -9,14 +9,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <member_of_group>rosidl_interface_packages</member_of_group>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <depend>geometry_msgs</depend>
-  <depend>ur_moveit_demo_msg</depend>
-  <depend>lock_service_msgs</depend>
-  <depend>lane_provider_msgs</depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros2_ws/src/lock_service_msgs/srv/Lock.srv
+++ b/ros2_ws/src/lock_service_msgs/srv/Lock.srv
@@ -1,0 +1,5 @@
+string lane_name
+string path_name
+bool lock_status
+---
+bool result

--- a/ros2_ws/src/otto_deliberation/CMakeLists.txt
+++ b/ros2_ws/src/otto_deliberation/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(rclcpp_action REQUIRED)
 find_package(blind_path_follower_msgs REQUIRED)
 find_package(lane_provider_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
+find_package(lock_service_msgs REQUIRED)
 
 add_executable(deliberation_otto_node src/deliberation_otto_node.cpp src/otto_autonomy.cpp src/nav2_action_client.cpp)
 target_include_directories(deliberation_otto_node PUBLIC
@@ -20,6 +21,7 @@ target_include_directories(deliberation_otto_node PUBLIC
 target_compile_features(deliberation_otto_node PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 ament_target_dependencies(
         deliberation_otto_node
+        lock_service_msgs
         "rclcpp"
         "rclcpp_action"
         "blind_path_follower_msgs"
@@ -29,6 +31,8 @@ ament_target_dependencies(
 
 install(TARGETS deliberation_otto_node
         DESTINATION lib/${PROJECT_NAME})
+
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
 if (BUILD_TESTING)
     find_package(ament_lint_auto REQUIRED)

--- a/ros2_ws/src/otto_deliberation/include/otto_deliberation/otto_autonomy.h
+++ b/ros2_ws/src/otto_deliberation/include/otto_deliberation/otto_autonomy.h
@@ -1,26 +1,36 @@
 
+#include <lock_service_msgs/srv/detail/lock__struct.hpp>
 #include <otto_deliberation/nav2_action_client.h>
 #include <otto_deliberation/robot_status.h>
 #include <otto_deliberation/tasks.h>
+#include <rclcpp/client.hpp>
 #include <rclcpp/logger.hpp>
+#include <rclcpp/node.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 
 #pragma once
 
 class OttoAutonomy
 {
 public:
-	OttoAutonomy(rclcpp::Node::SharedPtr node);
+	OttoAutonomy(rclcpp::Node::SharedPtr node, rclcpp::Node::SharedPtr lock_node);
 	void SetTasks(const Tasks& tasks, bool loop = true);
+	void SetLane(const std::string& lane_name);
 	void Update();
 	void NavigationGoalCompleted(bool success);
 	void NotifyCargoChanged(bool hasCargoNow);
 	RobotStatus GetCurrentStatus() const;
 
 private:
+	bool SendLockRequest(const std::string& path_name, bool lock_status);
+
 	rclcpp::Logger m_logger;
+	rclcpp::Client<lock_service_msgs::srv::Lock>::SharedPtr m_lockServiceClient;
 	RobotStatus m_robotStatus;
 	Nav2ActionClient m_nav2ActionClient;
 	Tasks m_tasks;  // front task is the current one.
+	std::string m_laneName;
 	bool m_loop;
+	bool m_hasLock;
 };

--- a/ros2_ws/src/otto_deliberation/include/otto_deliberation/tasks.h
+++ b/ros2_ws/src/otto_deliberation/include/otto_deliberation/tasks.h
@@ -21,7 +21,7 @@ struct Task
     RobotTaskStatus m_goalTaskStatus; // change to this status once task is completed.
 };
 
-typedef std::queue<Task> Tasks;
+typedef std::deque<Task> Tasks;
 typedef std::map<std::string, NavPath> NamedPathsMap;
 
 class TaskUtils

--- a/ros2_ws/src/otto_deliberation/launch/otto_deliberation.launch.py
+++ b/ros2_ws/src/otto_deliberation/launch/otto_deliberation.launch.py
@@ -13,7 +13,6 @@ def launch_setup(context, *args, **kwargs):
     nodes_to_start = []
 
     otto_deliberation = Node(
-        name="otto_deliberation",
         package="otto_deliberation",
         executable="deliberation_otto_node",
         namespace=namespace,

--- a/ros2_ws/src/otto_deliberation/package.xml
+++ b/ros2_ws/src/otto_deliberation/package.xml
@@ -13,6 +13,7 @@
   <depend>nav_msgs</depend>
   <depend>blind_path_follower_msgs</depend>
   <depend>lane_provider_msgs</depend>
+  <depend>lock_service_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/ros2_ws/src/otto_deliberation/src/otto_autonomy.cpp
+++ b/ros2_ws/src/otto_deliberation/src/otto_autonomy.cpp
@@ -1,11 +1,21 @@
 
 #include "otto_deliberation/robot_status.h"
+#include "otto_deliberation/tasks.h"
+#include <lock_service_msgs/srv/detail/lock__struct.hpp>
+#include <lock_service_msgs/srv/lock.hpp>
 #include <otto_deliberation/otto_autonomy.h>
 
-OttoAutonomy::OttoAutonomy(rclcpp::Node::SharedPtr node)
+OttoAutonomy::OttoAutonomy(rclcpp::Node::SharedPtr node, rclcpp::Node::SharedPtr lock_node)
     : m_logger(node->get_logger())
     , m_nav2ActionClient(node)
 {
+    std::string lock_service = lock_node->declare_parameter<std::string>("lock_service", "/lock_service");
+    lock_node->get_parameter<std::string>("lock_service", lock_service);
+    m_lockServiceClient = lock_node->create_client<lock_service_msgs::srv::Lock>(lock_service);
+    if (!m_lockServiceClient->wait_for_service(std::chrono::seconds(2)))
+    {
+        RCLCPP_ERROR(lock_node->get_logger(), "Lock service named %s not available", lock_service.c_str());
+    }
 }
 
 void OttoAutonomy::SetTasks(const Tasks& tasks, bool loop)
@@ -14,9 +24,26 @@ void OttoAutonomy::SetTasks(const Tasks& tasks, bool loop)
     m_tasks = tasks;
 }
 
+void OttoAutonomy::SetLane(const std::string& lane_name)
+{
+    m_laneName = lane_name;
+}
+
 RobotStatus OttoAutonomy::GetCurrentStatus() const
 {
     return m_robotStatus;
+}
+
+bool OttoAutonomy::SendLockRequest(const std::string& path_name, bool lock_status)
+{
+    auto lockRequest = std::make_shared<lock_service_msgs::srv::Lock::Request>();
+    lockRequest->lane_name = m_laneName;
+    lockRequest->path_name = path_name;
+    lockRequest->lock_status = lock_status;
+    auto future = m_lockServiceClient->async_send_request(lockRequest);
+    future.wait();
+    auto result = future.get();
+    return result->result;
 }
 
 void OttoAutonomy::Update()
@@ -34,12 +61,31 @@ void OttoAutonomy::Update()
             // Waiting for load/unload
             return;
         }
+
+        if (m_tasks.size() > 1)
+        {
+            if (m_tasks[1].m_requiresLock)
+            {
+                if (!SendLockRequest(m_tasks[1].m_taskKey, true))
+                {
+                    return;
+                }
+            }
+        }
+        if (currentTask.m_requiresLock)
+        {
+            if (!SendLockRequest(currentTask.m_taskKey, false))
+            {
+                return;
+            }
+        }
+
         // Current task completed!
         if (m_loop)
         {
-            m_tasks.push(currentTask);
+            m_tasks.push_back(currentTask);
         }
-        m_tasks.pop();
+        m_tasks.pop_front();
 
         // Go to next task if any
         if (m_tasks.empty())


### PR DESCRIPTION
I've created an orchestrator that manages locks on the path. This new orchestrator provides a service that enables AMRs to lock and unlock paths for their use. 
The orchestrator will automatically grab all available paths from the Editor using the lane service.
Paths are connected to the lane, but in the orchestrator, global paths can be specified (for example if we want to lock a path for all robots).
There is also a possibility to add path dependencies so that if a path depends on another path that is locked this path is also considered locked.

To launch the orchestrator use this command: ```ros2 launch demo_orchestration orchestration.launch.py```.