### PR TITLE
Fix for level prefab hierarchy

### DIFF
--- a/Project/Assets/Factory/Warehouse_300m2/Warehouse_300m2.prefab
+++ b/Project/Assets/Factory/Warehouse_300m2/Warehouse_300m2.prefab
@@ -377,73 +377,6 @@
                 }
             }
         },
-        "Entity_[1138625404291962]": {
-            "Id": "Entity_[1138625404291962]",
-            "Name": "Gate_lines",
-            "Components": {
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 17113014712055807565
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 13790103023037498798
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 16806358844540057503,
-                    "Child Entity Order": [
-                        "Instance_[1023954072456058]/ContainerEntity",
-                        "Instance_[1080445777300346]/ContainerEntity",
-                        "Instance_[1080548856515450]/ContainerEntity",
-                        "Instance_[1080561741417338]/ContainerEntity",
-                        "Instance_[1137422813449082]/ContainerEntity"
-                    ]
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 6978173428455281444,
-                    "ComponentOrderEntryArray": [
-                        {
-                            "ComponentId": 2757510667251557672
-                        }
-                    ]
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 2573270627241289491
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 2955156280763255893
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 16764046274712668057
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 13694524521424258694
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 2757510667251557672,
-                    "Parent Entity": "Entity_[351881303185622]",
-                    "Transform Data": {
-                        "Translate": [
-                            -1.7347564697265625,
-                            -4.668562889099121,
-                            0.0
-                        ],
-                        "Rotate": [
-                            0.0,
-                            0.0,
-                            180.0
-                        ]
-                    }
-                }
-            }
-        },
         "Entity_[1138732778474362]": {
             "Id": "Entity_[1138732778474362]",
             "Name": "Gate_lines",
@@ -460,11 +393,11 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 16806358844540057503,
                     "Child Entity Order": [
-                        "Instance_[1023954072456058]/ContainerEntity",
-                        "Instance_[1080445777300346]/ContainerEntity",
+                        "",
+                        "",
                         "Instance_[1080548856515450]/ContainerEntity",
                         "Instance_[1080561741417338]/ContainerEntity",
-                        "Instance_[1137422813449082]/ContainerEntity",
+                        "",
                         "Instance_[1138745663376250]/ContainerEntity",
                         "Instance_[1138737073441658]/ContainerEntity",
                         "Instance_[1138749958343546]/ContainerEntity",
@@ -504,7 +437,7 @@
                     "Transform Data": {
                         "Translate": [
                             -1.7347564697265625,
-                            4.684237480163574,
+                            -4.668562889099121,
                             0.0
                         ],
                         "Rotate": [
@@ -3060,8 +2993,8 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 16525521940788664722,
                     "Child Entity Order": [
-                        "Entity_[1138625404291962]",
                         "Entity_[1138732778474362]",
+                        "Entity_[35725374640646]",
                         "Entity_[351649374951638]",
                         "Entity_[1199729904012154]"
                     ]
@@ -3095,6 +3028,78 @@
                             -97.94430541992188,
                             15.097567558288574,
                             0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[35725374640646]": {
+            "Id": "Entity_[35725374640646]",
+            "Name": "Gate_lines",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17113014712055807565
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13790103023037498798
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16806358844540057503,
+                    "Child Entity Order": [
+                        "",
+                        "",
+                        "Instance_[1080548856515450]/ContainerEntity",
+                        "Instance_[1080561741417338]/ContainerEntity",
+                        "",
+                        "Instance_[1138745663376250]/ContainerEntity",
+                        "Instance_[1138737073441658]/ContainerEntity",
+                        "Instance_[1138749958343546]/ContainerEntity",
+                        "Instance_[1138754253310842]/ContainerEntity",
+                        "Instance_[1138741368408954]/ContainerEntity"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6978173428455281444,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2757510667251557672
+                        }
+                    ]
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2573270627241289491
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2955156280763255893
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 16764046274712668057
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13694524521424258694
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2757510667251557672,
+                    "Parent Entity": "Entity_[351881303185622]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.7347564697265625,
+                            4.684237480163574,
+                            0.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            180.0
                         ]
                     }
                 }
@@ -5096,51 +5101,6 @@
         }
     },
     "Instances": {
-        "Instance_[1023954072456058]": {
-            "Source": "Assets/Factory/Decals/Yellow_line_turn1.prefab",
-            "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
-                    "value": "../Entity_[1138625404291962]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
-                    "value": -1.396942138671875
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
-                    "value": 2.4735445976257324
-                }
-            ]
-        },
-        "Instance_[1080445777300346]": {
-            "Source": "Assets/Factory/Decals/Yellow_line_turn2.prefab",
-            "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
-                    "value": "../Entity_[1138625404291962]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
-                    "value": -1.396942138671875
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
-                    "value": -2.1657400131225586
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Rotate/2",
-                    "value": 180.0
-                }
-            ]
-        },
         "Instance_[1080548856515450]": {
             "Source": "Assets/Factory/Decals/Yellow_line_straight1.prefab",
             "Patches": [
@@ -5173,36 +5133,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
                     "value": 2.5403151512145996
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Rotate/2",
-                    "value": 89.99994659423828
-                }
-            ]
-        },
-        "Instance_[1137422813449082]": {
-            "Source": "Assets/Factory/Decals/Yellow_line_straight1.prefab",
-            "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[479150355860346]/Components/EditorNonUniformScaleComponent/NonUniformScale/1",
-                    "value": 0.800000011920929
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
-                    "value": "../Entity_[1138625404291962]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
-                    "value": -0.494720458984375
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
-                    "value": -2.2337121963500977
                 },
                 {
                     "op": "replace",
@@ -5372,7 +5302,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
-                    "value": -1.4646987915039065
+                    "value": -1.4646987915039063
                 },
                 {
                     "op": "replace",
@@ -8941,7 +8871,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
-                    "value": 0.49329185485839844
+                    "value": 0.4932918548583984
                 },
                 {
                     "op": "replace",
@@ -8971,7 +8901,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
-                    "value": -1.9618358612060547
+                    "value": -1.961835861206055
                 },
                 {
                     "op": "replace",
@@ -9026,7 +8956,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
-                    "value": -1.9637832641601563
+                    "value": -1.9637832641601565
                 },
                 {
                     "op": "replace",
@@ -9762,6 +9692,171 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Rotate/2",
                     "value": 89.99994659423828
+                }
+            ]
+        },
+        "Instance_[35729669607942]": {
+            "Source": "Assets/Factory/Decals/Yellow_line_straight1.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[479150355860346]/Components/EditorNonUniformScaleComponent/NonUniformScale/1",
+                    "value": 0.800000011920929
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
+                    "value": "../Entity_[35725374640646]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
+                    "value": -0.494720458984375
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
+                    "value": 2.5403151512145996
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Rotate/2",
+                    "value": 89.99994659423828
+                }
+            ]
+        },
+        "Instance_[35733964575238]": {
+            "Source": "Assets/Factory/Decals/Yellow_line_turn2.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
+                    "value": "../Entity_[35725374640646]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
+                    "value": -1.396942138671875
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
+                    "value": -2.1657400131225586
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Rotate/2",
+                    "value": 180.0
+                }
+            ]
+        },
+        "Instance_[35738259542534]": {
+            "Source": "Assets/Factory/Decals/Yellow_line_turn1.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
+                    "value": "../Entity_[35725374640646]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
+                    "value": -1.396942138671875
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
+                    "value": 2.4735445976257324
+                }
+            ]
+        },
+        "Instance_[35742554509830]": {
+            "Source": "Assets/Factory/Decals/Yellow_line_straight1.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[479150355860346]/Components/EditorNonUniformScaleComponent/NonUniformScale/1",
+                    "value": 0.800000011920929
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
+                    "value": "../Entity_[35725374640646]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
+                    "value": -0.494720458984375
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
+                    "value": -2.2337121963500977
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Rotate/2",
+                    "value": 89.99994659423828
+                }
+            ]
+        },
+        "Instance_[35746849477126]": {
+            "Source": "Assets/Factory/Decals/Yellow_line_straight1.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[479150355860346]/Components/EditorNonUniformScaleComponent/NonUniformScale/1",
+                    "value": 2.200000047683716
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
+                    "value": "../Entity_[35725374640646]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
+                    "value": -1.4646987915039065
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
+                    "value": 0.15633869171142578
+                }
+            ]
+        },
+        "Instance_[35802684051974]": {
+            "Source": "Assets/Factory/Decals/Gate_lines.prefab",
+            "Patches": [
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1137444288285562]/Components/EditorEntitySortComponent/Child Entity Order/3",
+                    "value": "Instance_[1137422813449082]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[1137444288285562]/Components/EditorEntitySortComponent/Child Entity Order/4",
+                    "value": "Instance_[1080561741417338]/ContainerEntity"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[1080548856515450]/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
+                    "value": -1.4646987915039063
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
+                    "value": "../Entity_[1199729904012154]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
+                    "value": 5.262603759765625
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
+                    "value": -5.002101898193359
                 }
             ]
         },

--- a/Project/Assets/Wrapper/Wrapper.prefab
+++ b/Project/Assets/Wrapper/Wrapper.prefab
@@ -50,6 +50,103 @@
         }
     },
     "Entities": {
+        "Entity_[155453635247189]": {
+            "Id": "Entity_[155453635247189]",
+            "Name": "Logic",
+            "Components": {
+                "EditorColliderComponent": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 7863973355119432943,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                2.0,
+                                2.0,
+                                2.0
+                            ]
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13293549367491089679
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13978706557958276908
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5390389658480573852
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6911989319475010841
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2244978636038446389
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4703299429121030539
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1557301694421745297
+                },
+                "EditorStaticRigidBodyComponent": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12624789126236103020
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14202080595680341005
+                },
+                "FoilWrapper": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 5321218964914144301,
+                    "m_template": {
+                        "$type": "FoilWrapper",
+                        "FoilWrapperConfig": {
+                            "FoilWrapperEntityId": "Entity_[2990724329371910]",
+                            "CollisionTrigger": "Entity_[155453635247189]",
+                            "SpawnablePayloadFoiled": {
+                                "assetId": {
+                                    "guid": "{0D44721F-2398-5BD7-80E0-81A23300265C}",
+                                    "subId": 346410741
+                                },
+                                "assetHint": "assets/factory/objects/palletstackpayloadfoil1.spawnable"
+                            }
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9690302264875424617,
+                    "Parent Entity": "Entity_[2990715739437318]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.026288986206054688,
+                            1.4855995178222656,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
         "Entity_[2990707149502726]": {
             "Id": "Entity_[2990707149502726]",
             "Name": "360_arm_001",
@@ -233,7 +330,8 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 11835557949134534592,
                     "Child Entity Order": [
-                        "Entity_[2990711444470022]"
+                        "Entity_[2990711444470022]",
+                        "Entity_[155453635247189]"
                     ]
                 },
                 "EditorInspectorComponent": {

--- a/Project/Levels/DemoLevel1/DemoLevel1.prefab
+++ b/Project/Levels/DemoLevel1/DemoLevel1.prefab
@@ -28,8 +28,9 @@
                     "Instance_[9613713711690]/ContainerEntity",
                     "Instance_[9849799017068]/ContainerEntity",
                     "Entity_[157997884966234]",
-                    "Instance_[2387492465947421]/ContainerEntity",
-                    "Entity_[1842731393655449]"
+                    "",
+                    "Entity_[1842731393655449]",
+                    "Instance_[34325215302150]/ContainerEntity"
                 ]
             },
             "Component_[15230859088967841193]": {
@@ -358,7 +359,7 @@
                     "m_template": {
                         "$type": "FoilWrapper",
                         "FoilWrapperConfig": {
-                            "FoilWrapperEntityId": "Instance_[2387492465947421]/Instance_[22762098693080]/Instance_[2990698559568134]/Entity_[2990724329371910]",
+                            "FoilWrapperEntityId": "",
                             "CollisionTrigger": "Entity_[23923972842980]",
                             "SpawnablePayloadFoiled": {
                                 "assetId": {
@@ -4793,41 +4794,6 @@
                 }
             ]
         },
-        "Instance_[2387492465947421]": {
-            "Source": "Assets/Factory/Objects/WarehouseObjects.prefab",
-            "Patches": [
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/8",
-                    "value": "Instance_[349072931332505]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/9",
-                    "value": "Instance_[349137355841945]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/10",
-                    "value": "Instance_[349098701136281]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/11",
-                    "value": "Instance_[349124470940057]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/12",
-                    "value": "Instance_[349111586038169]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/13",
-                    "value": "Instance_[349085816234393]/ContainerEntity"
-                }
-            ]
-        },
         "Instance_[23912791405281]": {
             "Source": "Prefabs/Otto600-Stand/Otto600Stand_fbx.prefab",
             "Patches": [
@@ -5164,6 +5130,76 @@
                 }
             ]
         },
+        "Instance_[34325215302150]": {
+            "Source": "Assets/Factory/Objects/WarehouseObjects.prefab",
+            "Patches": [
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[22762098693080]/Entities/Entity_[3487630570682630]/Components/EditorEntitySortComponent/Child Entity Order/13",
+                    "value": "Instance_[628116669736867]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[22762098693080]/Entities/Entity_[3487630570682630]/Components/EditorEntitySortComponent/Child Entity Order/14",
+                    "value": "Instance_[627974935816099]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[22762098693080]/Entities/Entity_[3487630570682630]/Components/EditorEntitySortComponent/Child Entity Order/15",
+                    "value": "Instance_[628090899933091]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Instances/Instance_[22762098693080]/Entities/Entity_[3487630570682630]/Components/EditorEntitySortComponent/Child Entity Order/16",
+                    "value": "Instance_[628103784834979]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[32799934489056]/Components/EditorEntitySortComponent/Child Entity Order/1",
+                    "value": "Instance_[55376356293708]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/8",
+                    "value": "Instance_[349137355841945]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/9",
+                    "value": "Instance_[349150240743833]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/10",
+                    "value": "Instance_[349111586038169]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/11",
+                    "value": "Instance_[349124470940057]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/12",
+                    "value": "Instance_[349098701136281]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/13",
+                    "value": "Instance_[349085816234393]/ContainerEntity"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[342729264636313]/Components/EditorEntitySortComponent/Child Entity Order/14",
+                    "value": "Instance_[349072931332505]/ContainerEntity"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
+                    "value": "../Entity_[1146574390643]"
+                }
+            ]
+        },
         "Instance_[4001389725264]": {
             "Source": "Assets/Factory/Workstation/CellConveyor.prefab",
             "Patches": [
@@ -5286,6 +5322,18 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
                     "value": "../Entity_[1146574390643]"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Instances/Instance_[1080548856515450]"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Instances/Instance_[1080561741417338]"
+                },
+                {
+                    "op": "remove",
+                    "path": "/Instances/Instance_[1137435698350970]"
                 }
             ]
         },

--- a/Project/Levels/DemoLevel1/DemoLevel1.prefab
+++ b/Project/Levels/DemoLevel1/DemoLevel1.prefab
@@ -329,7 +329,6 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 2672495052795386936,
                     "Child Entity Order": [
-                        "Entity_[23923972842980]",
                         "Entity_[139541114672457]"
                     ]
                 },
@@ -360,7 +359,7 @@
                         "$type": "FoilWrapper",
                         "FoilWrapperConfig": {
                             "FoilWrapperEntityId": "",
-                            "CollisionTrigger": "Entity_[23923972842980]",
+                            "CollisionTrigger": "",
                             "SpawnablePayloadFoiled": {
                                 "assetId": {
                                     "guid": "{0D44721F-2398-5BD7-80E0-81A23300265C}",
@@ -2134,12 +2133,12 @@
                                 "Vertices": [
                                     [
                                         -6.606531143188477,
-                                        -4.083436965942383,
+                                        -2.848562002182007,
                                         0.12432372570037842
                                     ],
                                     [
                                         -1.8644790649414063,
-                                        -4.10443115234375,
+                                        -2.8785088062286377,
                                         0.1243208646774292
                                     ],
                                     [
@@ -2357,85 +2356,6 @@
                             -102.79818725585938,
                             10.459091186523438,
                             0.0
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[23923972842980]": {
-            "Id": "Entity_[23923972842980]",
-            "Name": "Collider",
-            "Components": {
-                "EditorColliderComponent": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 12441977599599685893,
-                    "ColliderConfiguration": {
-                        "Trigger": true,
-                        "InSceneQueries": false,
-                        "MaterialSlots": {
-                            "Slots": [
-                                {
-                                    "Name": "Entire object"
-                                }
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "ShapeType": 1,
-                        "Box": {
-                            "Configuration": [
-                                2.0,
-                                2.0,
-                                2.0
-                            ]
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8537793346913250817
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 17269105487848526776
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 12201774849176485451
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 11567194923707562191
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 16240257743198407771
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 5240309350857304956
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 3506376165812444596
-                },
-                "EditorStaticRigidBodyComponent": {
-                    "$type": "EditorStaticRigidBodyComponent",
-                    "Id": 3255264693798359515
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 4177265803681788129
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 11815668708255775981,
-                    "Parent Entity": "Entity_[139536819705161]",
-                    "Transform Data": {
-                        "Translate": [
-                            -28.93921661376953,
-                            17.700000762939453,
-                            1.160773515701294
                         ]
                     }
                 }
@@ -2843,13 +2763,13 @@
                             "Vertices": {
                                 "Vertices": [
                                     [
-                                        -6.405857563018799,
-                                        -7.298173904418945,
+                                        -7.0023674964904785,
+                                        -6.930393218994141,
                                         -0.12433278560638428
                                     ],
                                     [
                                         -1.793186902999878,
-                                        -7.274762153625488,
+                                        -6.948859691619873,
                                         -0.12433040142059326
                                     ],
                                     [


### PR DESCRIPTION
Level cleanup (#184) broke the hierarchy of some objects. This is the fix for it.
Before:
![image](https://github.com/RobotecAI/ROSCon2023Demo/assets/31925544/654e79bc-8a9c-4607-8fed-74adb49440ba)

After:
![Screenshot from 2023-10-05 19-50-54](https://github.com/RobotecAI/ROSCon2023Demo/assets/31925544/14f80ad9-f26b-477a-83a9-7a39f2aeb0ec)
