### PR TITLE
Nav2 in composition mode by default

### DIFF
--- a/ros2_ws/src/otto_fleet_nav/launch/otto_bringup_launch.py
+++ b/ros2_ws/src/otto_fleet_nav/launch/otto_bringup_launch.py
@@ -88,7 +88,7 @@ def generate_launch_description():
         description='Automatically startup the nav2 stack')
 
     declare_use_composition_cmd = DeclareLaunchArgument(
-        'use_composition', default_value='False',
+        'use_composition', default_value='True',
         description='Whether to use composed bringup')
 
     declare_use_respawn_cmd = DeclareLaunchArgument(

--- a/ros2_ws/src/otto_fleet_nav/launch/otto_fleet_nav_launch.py
+++ b/ros2_ws/src/otto_fleet_nav/launch/otto_fleet_nav_launch.py
@@ -127,6 +127,7 @@ def launch_setup(context, *args, **kwargs):
                                                            'otto_nav_launch.py')),
                 launch_arguments={'namespace': robot['namespace'],
                                   'use_namespace': 'True',
+                                  'use_composition': 'True',
                                   'map': map_yaml_file,
                                   'use_sim_time': 'True',
                                   'params_file': configured_params,

--- a/ros2_ws/src/otto_fleet_nav/launch/otto_localization_launch.py
+++ b/ros2_ws/src/otto_fleet_nav/launch/otto_localization_launch.py
@@ -85,7 +85,7 @@ def generate_launch_description():
         description='Automatically startup the nav2 stack')
 
     declare_use_composition_cmd = DeclareLaunchArgument(
-        'use_composition', default_value='False',
+        'use_composition', default_value='True',
         description='Use composed bringup if True')
 
     declare_container_name_cmd = DeclareLaunchArgument(

--- a/ros2_ws/src/otto_fleet_nav/launch/otto_nav_launch.py
+++ b/ros2_ws/src/otto_fleet_nav/launch/otto_nav_launch.py
@@ -78,7 +78,7 @@ def generate_launch_description():
         description='Automatically startup the nav2 stack')
 
     declare_use_composition_cmd = DeclareLaunchArgument(
-        'use_composition', default_value='False',
+        'use_composition', default_value='True',
         description='Whether to use composed bringup')
 
     declare_use_respawn_cmd = DeclareLaunchArgument(

--- a/ros2_ws/src/otto_fleet_nav/launch/otto_navigation_launch.py
+++ b/ros2_ws/src/otto_fleet_nav/launch/otto_navigation_launch.py
@@ -85,7 +85,7 @@ def generate_launch_description():
         description='Automatically startup the nav2 stack')
 
     declare_use_composition_cmd = DeclareLaunchArgument(
-        'use_composition', default_value='False',
+        'use_composition', default_value='True',
         description='Use composed bringup if True')
 
     declare_container_name_cmd = DeclareLaunchArgument(


### PR DESCRIPTION
Make sure that you have the most recent version of `ros-humble-launch-ros` (0.19.6+). Previous versions have bug that brakes the composition in nav2. More info [here](https://github.com/ros-planning/navigation2/issues/3644#issuecomment-1621868786). 