### PR TITLE
Move config files to groups

### DIFF
--- a/ros2_ws/src/roscon2023_demo/config/ROSCon2023Config_900_group1.yaml
+++ b/ros2_ws/src/roscon2023_demo/config/ROSCon2023Config_900_group1.yaml
@@ -1,0 +1,99 @@
+fleet:
+# Group 1
+  - robot_name: otto600
+    robot_namespace: otto_1
+    lane: Line1
+    tasks_config_file: config/otto600_tasks_12.yaml
+    nav2_param_file: otto600Params.yaml
+    position: 
+      x: -32.0
+      y: 2.0
+      z: 0.1
+
+  - robot_name: otto600
+    robot_namespace: otto_2
+    lane: Line1
+    tasks_config_file: config/otto600_tasks_12.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -30.0
+      y: 2.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_3
+    lane: Line2
+    tasks_config_file: config/otto600_tasks_12.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -28.0
+      y: 2.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_4
+    lane: Line2
+    tasks_config_file: config/otto600_tasks_12.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -26.0
+      y: 2.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_5
+    lane: Line3
+    tasks_config_file: config/otto600_tasks_34.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -32.0
+      y: 27.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_6
+    lane: Line3
+    tasks_config_file: config/otto600_tasks_34.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -30.0
+      y: 27.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_7
+    lane: Line4
+    tasks_config_file: config/otto600_tasks_34.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -28.0
+      y: 27.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_8
+    lane: Line4
+    tasks_config_file: config/otto600_tasks_34.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -26.0
+      y: 27.0
+      z: 0.2
+
+arms:
+# Group 1
+  - namespace: ur1
+    num_of_boxes: 6
+    launch_rviz: false
+
+  - namespace: ur2
+    num_of_boxes: 6
+    launch_rviz: false
+
+  - namespace: ur3
+    num_of_boxes: 6
+    launch_rviz: false
+
+  - namespace: ur4
+    num_of_boxes: 6
+    launch_rviz: false

--- a/ros2_ws/src/roscon2023_demo/config/ROSCon2023Config_900_group2.yaml
+++ b/ros2_ws/src/roscon2023_demo/config/ROSCon2023Config_900_group2.yaml
@@ -1,0 +1,100 @@
+fleet:
+  
+  - robot_name: otto600
+    robot_namespace: otto_21
+    lane: Line21
+    tasks_config_file: config/otto600_tasks_12_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position: 
+      x: -32.0
+      y: 32.0
+      z: 0.1
+
+  - robot_name: otto600
+    robot_namespace: otto_22
+    lane: Line21
+    tasks_config_file: config/otto600_tasks_12_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -30.0
+      y: 32.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_23
+    lane: Line22
+    tasks_config_file: config/otto600_tasks_12_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -28.0
+      y: 32.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_24
+    lane: Line22
+    tasks_config_file: config/otto600_tasks_12_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -26.0
+      y: 32.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_25
+    lane: Line23
+    tasks_config_file: config/otto600_tasks_34_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -32.0
+      y: 57.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_26
+    lane: Line23
+    tasks_config_file: config/otto600_tasks_34_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -30.0
+      y: 57.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_27
+    lane: Line24
+    tasks_config_file: config/otto600_tasks_34_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -28.0
+      y: 57.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_28
+    lane: Line24
+    tasks_config_file: config/otto600_tasks_34_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -26.0
+      y: 57.0
+      z: 0.2
+
+arms:
+# Group 2
+
+  - namespace: ur5
+    num_of_boxes: 6
+    launch_rviz: false
+
+  - namespace: ur6
+    num_of_boxes: 6
+    launch_rviz: false
+
+  - namespace: ur7
+    num_of_boxes: 6
+    launch_rviz: false
+
+  - namespace: ur8
+    num_of_boxes: 6
+    launch_rviz: false

--- a/ros2_ws/src/roscon2023_demo/config/ROSCon2023Config_900_group3.yaml
+++ b/ros2_ws/src/roscon2023_demo/config/ROSCon2023Config_900_group3.yaml
@@ -1,0 +1,100 @@
+fleet:
+  - robot_name: otto600
+    robot_namespace: otto_31
+    lane: Line31
+    tasks_config_file: config/otto600_tasks_12_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position: 
+      x: -32.0
+      y: 62.0
+      z: 0.1
+
+  - robot_name: otto600
+    robot_namespace: otto_32
+    lane: Line31
+    tasks_config_file: config/otto600_tasks_12_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -30.0
+      y: 62.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_33
+    lane: Line32
+    tasks_config_file: config/otto600_tasks_12_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -28.0
+      y: 62.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_34
+    lane: Line32
+    tasks_config_file: config/otto600_tasks_12_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -26.0
+      y: 62.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_35
+    lane: Line33
+    tasks_config_file: config/otto600_tasks_34_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -32.0
+      y: 87.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_36
+    lane: Line33
+    tasks_config_file: config/otto600_tasks_34_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -30.0
+      y: 87.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_37
+    lane: Line34
+    tasks_config_file: config/otto600_tasks_34_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -28.0
+      y: 87.0
+      z: 0.2
+
+  - robot_name: otto600
+    robot_namespace: otto_38
+    lane: Line34
+    tasks_config_file: config/otto600_tasks_34_lane2.yaml
+    nav2_param_file: otto600Params.yaml
+    position:
+      x: -26.0
+      y: 87.0
+      z: 0.2
+      
+
+arms:
+# Group 3
+
+  - namespace: ur9
+    num_of_boxes: 6
+    launch_rviz: false
+
+  - namespace: ur10
+    num_of_boxes: 6
+    launch_rviz: false   
+
+  - namespace: ur11
+    num_of_boxes: 6
+    launch_rviz: false
+
+  - namespace: ur12
+    num_of_boxes: 6
+    launch_rviz: false


### PR DESCRIPTION
This is a proposition to extract configurations into groups for the bigger level. These groups divide all 12 lanes into 3 groups.