### PR TITLE
Fix otto odom warn

### DIFF
--- a/Project/Prefabs/OTTO600/OTTO600WithPallet.prefab
+++ b/Project/Prefabs/OTTO600/OTTO600WithPallet.prefab
@@ -134,26 +134,6 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[376437113355]/Components/EditorTagComponent/Id",
-                    "value": 7864192969969983559
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 3
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
-                    "value": "otto_1"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[376437113355]/Components/SkidSteeringModelComponent/m_template/ManualControl",
-                    "value": false
-                },
-                {
-                    "op": "replace",
                     "path": "/Entities/Entity_[385027047947]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/assetHint",
                     "value": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.stl.azmodel"
                 },
@@ -208,6 +188,31 @@
                     "op": "replace",
                     "path": "/Entities/Entity_[483811295755]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/assetHint",
                     "value": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.stl.azmodel"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[376437113355]/Components/EditorTagComponent/Id",
+                    "value": 7864192969969983559
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 3
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "value": "otto_1"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[376437113355]/Components/ROS2OdometrySensorComponent/m_template/SensorConfiguration/Publishers/nav_msgs::msg::Odometry/QoS/Reliability",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[376437113355]/Components/SkidSteeringModelComponent/m_template/ManualControl",
+                    "value": false
                 }
             ]
         },


### PR DESCRIPTION
I've fixed the warning displayed in the o3de console regarding otto/odom. 
![image](https://github.com/RobotecAI/ROSCon2023Demo/assets/130671280/d239751d-6479-4eb0-8530-b2548bac2a8d)
 I've changed the Ottos odometry sensors' QoS to reliable.