### PR TITLE
Change lidar implementation to scene querry.

### DIFF
--- a/Project/Prefabs/OTTO600/OTTO600WithPallet.prefab
+++ b/Project/Prefabs/OTTO600/OTTO600WithPallet.prefab
@@ -213,6 +213,16 @@
                     "op": "replace",
                     "path": "/Entities/Entity_[376437113355]/Components/SkidSteeringModelComponent/m_template/ManualControl",
                     "value": false
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[187685058540532]/Components/ROS2Lidar2DSensorComponent/m_template/lidarCore/lidarConfiguration/lidarImplementation",
+                    "value": "Scene Queries"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[207905764570100]/Components/ROS2Lidar2DSensorComponent/m_template/lidarCore/lidarConfiguration/lidarImplementation",
+                    "value": "Scene Queries"
                 }
             ]
         },


### PR DESCRIPTION
Lidar implementation was missing in ottowithpallet.prefab. I've changed it to scene querries.