### PR TITLE
OTTO 600 and 1500 fixes and visual improvements

### DIFF
--- a/Project/Assets/Importer/OTTO1500_Basic_platform.prefab
+++ b/Project/Assets/Importer/OTTO1500_Basic_platform.prefab
@@ -120,17 +120,17 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15694439630999630996,
-                    "Parent Entity": "Entity_[2506590024219]",
+                    "Parent Entity": "Entity_[2519474926107]",
                     "Transform Data": {
                         "Translate": [
-                            -0.6000001430511475,
-                            0.85999995470047,
-                            0.09999999403953552
+                            0.8600006103515625,
+                            0.6000003814697266,
+                            0.09999998658895493
                         ],
                         "Rotate": [
                             0.0,
                             0.0,
-                            180.0
+                            89.99998474121094
                         ]
                     }
                 }
@@ -206,12 +206,17 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15694439630999630996,
-                    "Parent Entity": "Entity_[2506590024219]",
+                    "Parent Entity": "Entity_[2519474926107]",
                     "Transform Data": {
                         "Translate": [
-                            0.6000001430511475,
-                            -0.8599998950958252,
-                            0.09999999403953552
+                            -0.8600006103515625,
+                            -0.5999999046325684,
+                            0.09999998658895493
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            -89.99999237060547
                         ]
                     }
                 }
@@ -231,7 +236,7 @@
                                     "guid": "{70D97A0E-96CB-5FA7-975D-7CE7DC3CEA63}",
                                     "subId": 268916636
                                 },
-                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_front_rear.azmodel"
+                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_front_rear.stl.azmodel"
                             }
                         }
                     }
@@ -255,6 +260,29 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 16921680879763803478
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 2409508638397428710,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            },
+                                            "assetHint": "materials/presets/macbeth/24_black_2-0_1-50d.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -282,201 +310,6 @@
                             0.0,
                             0.0,
                             89.99999237060547
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[2424985645595]": {
-            "Id": "Entity_[2424985645595]",
-            "Name": "lights_front_right",
-            "Components": {
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 7587756992547510330
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 4398300183131950651
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 8623555211141947147,
-                    "Child Entity Order": [
-                        "Entity_[2450755449371]",
-                        "Entity_[2446460482075]"
-                    ]
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 2691391330247274228
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 11157075607780090074
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 5540099253879459478
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 17249713216533827311
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 6932711339470502100
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 5215931359061447226,
-                    "Parent Entity": "Entity_[2506590024219]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.3637009859085083,
-                            0.8812189698219299,
-                            0.3009859025478363
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[2429280612891]": {
-            "Id": "Entity_[2429280612891]",
-            "Name": "lights_front_left",
-            "Components": {
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 7587756992547510330
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 4398300183131950651
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 8623555211141947147,
-                    "Child Entity Order": [
-                        "Entity_[2459345383963]",
-                        "Entity_[2433575580187]"
-                    ]
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 2691391330247274228
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 11157075607780090074
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 5540099253879459478
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 17249713216533827311
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 6932711339470502100
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 5215931359061447226,
-                    "Parent Entity": "Entity_[2506590024219]",
-                    "Transform Data": {
-                        "Translate": [
-                            -0.6142675280570984,
-                            0.8808804750442505,
-                            0.3010312616825104
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[2433575580187]": {
-            "Id": "Entity_[2433575580187]",
-            "Name": "left",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                0.6802624464035034,
-                                0.6802624464035034,
-                                0.401022344827652
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 7.266918182373047
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        0.6802624464035034,
-                        0.6802624464035034,
-                        0.401022344827652,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[2429280612891]",
-                    "Transform Data": {
-                        "Translate": [
-                            -0.037393927574157715,
-                            -0.08997642993927002,
-                            -0.009903758764266968
-                        ],
-                        "Rotate": [
-                            178.7519073486328,
-                            24.367582321166992,
-                            -86.97740936279297
                         ]
                     }
                 }
@@ -752,267 +585,6 @@
                 }
             }
         },
-        "Entity_[2446460482075]": {
-            "Id": "Entity_[2446460482075]",
-            "Name": "right",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                0.6802624464035034,
-                                0.6802624464035034,
-                                0.401022344827652
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 7.266918182373047
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        0.6802624464035034,
-                        0.6802624464035034,
-                        0.401022344827652,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[2424985645595]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.2821972072124481,
-                            -0.08989912271499634,
-                            0.021053224802017212
-                        ],
-                        "Rotate": [
-                            -178.98049926757813,
-                            43.831703186035156,
-                            -88.7185287475586
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[2450755449371]": {
-            "Id": "Entity_[2450755449371]",
-            "Name": "front",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                0.6802624464035034,
-                                0.6802624464035034,
-                                0.401022344827652
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 7.266918182373047
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        0.6802624464035034,
-                        0.6802624464035034,
-                        0.401022344827652,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[2424985645595]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.11914092302322388,
-                            0.04450613260269165,
-                            0.011720985174179077
-                        ],
-                        "Rotate": [
-                            -164.45391845703125,
-                            0.0000022315971364150755,
-                            0.00001003567194857169
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[2459345383963]": {
-            "Id": "Entity_[2459345383963]",
-            "Name": "front",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                0.6802624464035034,
-                                0.6802624464035034,
-                                0.401022344827652
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 7.266918182373047
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        0.6802624464035034,
-                        0.6802624464035034,
-                        0.401022344827652,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[2429280612891]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.11914092302322388,
-                            0.04450613260269165,
-                            0.011720985174179077
-                        ],
-                        "Rotate": [
-                            -164.45391845703125,
-                            0.0000022315971364150755,
-                            0.00001003567194857169
-                        ]
-                    }
-                }
-            }
-        },
         "Entity_[2463640351259]": {
             "Id": "Entity_[2463640351259]",
             "Name": "wheel_FR_visual",
@@ -1027,7 +599,7 @@
                                     "guid": "{70D97A0E-96CB-5FA7-975D-7CE7DC3CEA63}",
                                     "subId": 268916636
                                 },
-                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_front_rear.azmodel"
+                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_front_rear.stl.azmodel"
                             }
                         }
                     }
@@ -1051,6 +623,29 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 3134686650868325344
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 8435814910654764318,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            },
+                                            "assetHint": "materials/presets/macbeth/24_black_2-0_1-50d.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -1097,7 +692,7 @@
                                     "guid": "{70D97A0E-96CB-5FA7-975D-7CE7DC3CEA63}",
                                     "subId": 268916636
                                 },
-                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_front_rear.azmodel"
+                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_front_rear.stl.azmodel"
                             }
                         }
                     }
@@ -1121,6 +716,29 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 9948243621989815891
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 729521378073652677,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            },
+                                            "assetHint": "materials/presets/macbeth/24_black_2-0_1-50d.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -1404,60 +1022,6 @@
                 }
             }
         },
-        "Entity_[2480820220443]": {
-            "Id": "Entity_[2480820220443]",
-            "Name": "lights_rear_left",
-            "Components": {
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 7587756992547510330
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 4398300183131950651
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 8623555211141947147,
-                    "Child Entity Order": [
-                        "Entity_[2540949762587]",
-                        "Entity_[2523769893403]"
-                    ]
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 2691391330247274228
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 11157075607780090074
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 5540099253879459478
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 17249713216533827311
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 6932711339470502100
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 5215931359061447226,
-                    "Parent Entity": "Entity_[2506590024219]",
-                    "Transform Data": {
-                        "Translate": [
-                            -0.674261212348938,
-                            -0.7144314646720886,
-                            0.3009859025478363
-                        ]
-                    }
-                }
-            }
-        },
         "Entity_[2485115187739]": {
             "Id": "Entity_[2485115187739]",
             "Name": "wheel_RR_visual",
@@ -1472,7 +1036,7 @@
                                     "guid": "{70D97A0E-96CB-5FA7-975D-7CE7DC3CEA63}",
                                     "subId": 268916636
                                 },
-                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_front_rear.azmodel"
+                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_front_rear.stl.azmodel"
                             }
                         }
                     }
@@ -1496,6 +1060,29 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 7946680031947169975
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 7962671322397135937,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            },
+                                            "assetHint": "materials/presets/macbeth/24_black_2-0_1-50d.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -1798,60 +1385,6 @@
                 }
             }
         },
-        "Entity_[2498000089627]": {
-            "Id": "Entity_[2498000089627]",
-            "Name": "lights_rear_right",
-            "Components": {
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 7587756992547510330
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 4398300183131950651
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 8623555211141947147,
-                    "Child Entity Order": [
-                        "Entity_[2532359827995]",
-                        "Entity_[2510884991515]"
-                    ]
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 2691391330247274228
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 11157075607780090074
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 5540099253879459478
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 17249713216533827311
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 6932711339470502100
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 5215931359061447226,
-                    "Parent Entity": "Entity_[2506590024219]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.36370086669921875,
-                            -0.7144318222999573,
-                            0.3009859025478363
-                        ]
-                    }
-                }
-            }
-        },
         "Entity_[2502295056923]": {
             "Id": "Entity_[2502295056923]",
             "Name": "wheel_CR_visual",
@@ -1866,7 +1399,7 @@
                                     "guid": "{C270CA73-FFF1-55D8-95AC-87A91812E383}",
                                     "subId": 277864421
                                 },
-                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_center.azmodel"
+                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_center.stl.azmodel"
                             }
                         }
                     }
@@ -1890,6 +1423,29 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 2587893789026457139
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 5477537730430053811,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            },
+                                            "assetHint": "materials/presets/macbeth/24_black_2-0_1-50d.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -1953,12 +1509,10 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 16889000206496806826,
                     "Child Entity Order": [
-                        "Entity_[16359154575719]",
-                        "Entity_[16363449543015]",
-                        "Entity_[2480820220443]",
-                        "Entity_[2424985645595]",
-                        "Entity_[2498000089627]",
-                        "Entity_[2429280612891]"
+                        "Entity_[58050727087217]",
+                        "Entity_[58055022054513]",
+                        "Entity_[58188166040689]",
+                        "Entity_[58085086825585]"
                     ]
                 },
                 "EditorInspectorComponent": {
@@ -2052,93 +1606,6 @@
                             0.0,
                             0.0,
                             -90.0
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[2510884991515]": {
-            "Id": "Entity_[2510884991515]",
-            "Name": "right",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                1.0,
-                                0.09279011189937592,
-                                0.006515602581202984
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 4.728076934814453
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        1.0,
-                        0.09279011189937592,
-                        0.006515602581202984,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[2498000089627]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.2754446864128113,
-                            -0.10337775945663452,
-                            0.014488428831100464
-                        ],
-                        "Rotate": [
-                            179.8093719482422,
-                            41.04417037963867,
-                            -87.87556457519531
                         ]
                     }
                 }
@@ -2401,6 +1868,8 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 15576807478814498979,
                     "Child Entity Order": [
+                        "Entity_[16359154575719]",
+                        "Entity_[16363449543015]",
                         "Entity_[2476525253147]",
                         "Entity_[2437870547483]",
                         "Entity_[2472230285851]",
@@ -2467,6 +1936,47 @@
                                 "guid": "{7D2DCE6D-3A85-5781-9EBB-3CA0D979919D}"
                             },
                             "assetHint": "prefabs/otto1500/scripts/otto1500robot_inputs.inputbindings"
+                        }
+                    }
+                },
+                "LightController": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 4877734363010090127,
+                    "m_template": {
+                        "$type": "LightController",
+                        "configuration": {
+                            "LightEntityIdList": [
+                                "Entity_[58072201923697]",
+                                "Entity_[58136626433137]",
+                                "Entity_[58170986171505]",
+                                "Entity_[58089381792881]",
+                                "Entity_[58067906956401]",
+                                "Entity_[58093676760177]",
+                                "Entity_[58042137152625]",
+                                "Entity_[58175281138801]",
+                                "Entity_[58132331465841]",
+                                "Entity_[58123741531249]",
+                                "Entity_[58149511335025]",
+                                "Entity_[58063611989105]",
+                                "Entity_[58192461007985]",
+                                "Entity_[58097971727473]",
+                                "Entity_[58179576106097]",
+                                "Entity_[58119446563953]",
+                                "Entity_[58196755975281]",
+                                "Entity_[58106561662065]",
+                                "Entity_[58166691204209]",
+                                "Entity_[58183871073393]",
+                                "Entity_[58102266694769]",
+                                "Entity_[58033547218033]",
+                                "Entity_[58162396236913]",
+                                "Entity_[58153806302321]"
+                            ],
+                            "TopicConfiguration": {
+                                "Topic": "color",
+                                "QoS": {
+                                    "Reliability": 1
+                                }
+                            }
                         }
                     }
                 },
@@ -2542,93 +2052,6 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15848641852368889391,
                     "Parent Entity": "ContainerEntity"
-                }
-            }
-        },
-        "Entity_[2523769893403]": {
-            "Id": "Entity_[2523769893403]",
-            "Name": "rear",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                1.0,
-                                0.09279011189937592,
-                                0.006515602581202984
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 4.728076934814453
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        1.0,
-                        0.09279011189937592,
-                        0.006515602581202984,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[2480820220443]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.19255352020263672,
-                            -0.20787888765335083,
-                            0.011416405439376831
-                        ],
-                        "Rotate": [
-                            162.54373168945313,
-                            -0.6320992112159729,
-                            -4.677469730377197
-                        ]
-                    }
                 }
             }
         },
@@ -2725,93 +2148,6 @@
                 }
             }
         },
-        "Entity_[2532359827995]": {
-            "Id": "Entity_[2532359827995]",
-            "Name": "rear",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                1.0,
-                                0.09279011189937592,
-                                0.006515602581202984
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 4.728076934814453
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        1.0,
-                        0.09279011189937592,
-                        0.006515602581202984,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[2498000089627]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.1034647524356842,
-                            -0.20430141687393188,
-                            0.011321723461151123
-                        ],
-                        "Rotate": [
-                            162.54373168945313,
-                            -0.6320992112159729,
-                            -4.677469730377197
-                        ]
-                    }
-                }
-            }
-        },
         "Entity_[2536654795291]": {
             "Id": "Entity_[2536654795291]",
             "Name": "wheel_CL_visual",
@@ -2826,7 +2162,7 @@
                                     "guid": "{C270CA73-FFF1-55D8-95AC-87A91812E383}",
                                     "subId": 277864421
                                 },
-                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_center.azmodel"
+                                "assetHint": "assets/urdfimporter/2620430307_otto1500_basic_platform.urdf/otto1500_wheel_center.stl.azmodel"
                             }
                         }
                     }
@@ -2850,6 +2186,29 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 13624607714717207676
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 16880595923736263641,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            },
+                                            "assetHint": "materials/presets/macbeth/24_black_2-0_1-50d.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -2882,88 +2241,2297 @@
                 }
             }
         },
-        "Entity_[2540949762587]": {
-            "Id": "Entity_[2540949762587]",
-            "Name": "left",
+        "Entity_[58033547218033]": {
+            "Id": "Entity_[58033547218033]",
+            "Name": "in_FR",
             "Components": {
                 "AZ::Render::EditorAreaLightComponent": {
                     "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
+                    "Id": 1785973739929303350,
                     "Controller": {
                         "Configuration": {
                             "LightType": 4,
-                            "Color": [
-                                1.0,
-                                0.09279011189937592,
-                                0.006515602581202984
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 4.728076934814453
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
                         }
                     }
                 },
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
+                    "Id": 9674813848600866137
                 },
                 "EditorEntityIconComponent": {
                     "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
+                    "Id": 16233921723394238903
                 },
                 "EditorEntitySortComponent": {
                     "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
+                    "Id": 16687462048376832276
                 },
                 "EditorInspectorComponent": {
                     "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
+                    "Id": 10667933295669397881
                 },
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
+                    "Id": 6759913094008271528
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
+                    "Id": 1338086874615879553
                 },
                 "EditorPendingCompositionComponent": {
                     "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
+                    "Id": 15993105608309907256
                 },
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
+                    "Id": 15762540797896440595
                 },
                 "LmbrCentral::EditorQuadShapeComponent": {
                     "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
+                    "Id": 3162277983435690611,
                     "ShapeColor": [
                         1.0,
-                        0.09279011189937592,
-                        0.006515602581202984,
+                        1.0,
+                        1.0,
                         1.0
                     ],
                     "QuadShape": {
                         "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
                         }
                     }
                 },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[2480820220443]",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58085086825585]",
                     "Transform Data": {
                         "Translate": [
-                            0.029989778995513916,
-                            -0.12438899278640747,
-                            -0.0036117732524871826
+                            -0.03021073341369629,
+                            0.16726303100585938,
+                            -0.012516915798187256
                         ],
                         "Rotate": [
-                            179.8093719482422,
-                            41.04417037963867,
-                            -87.87556457519531
+                            -89.9998779296875,
+                            89.99988555908203,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58042137152625]": {
+            "Id": "Entity_[58042137152625]",
+            "Name": "in_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58055022054513]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.03137779235839844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58050727087217]": {
+            "Id": "Entity_[58050727087217]",
+            "Name": "Light_RR",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9172069229325435484
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8206619370733550280
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13793705696556064625,
+                    "Child Entity Order": [
+                        "Entity_[58072201923697]",
+                        "Entity_[58136626433137]",
+                        "Entity_[58170986171505]",
+                        "Entity_[58089381792881]",
+                        "Entity_[58067906956401]",
+                        "Entity_[58093676760177]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13161780626403192255
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2387504988228675296
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10169122181495623720
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9338808403578171831
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12707161379298739703
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10394210563839849370,
+                    "Parent Entity": "Entity_[2506590024219]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.5959763526916504,
+                            -0.8714046478271484,
+                            0.30724820494651794
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            89.99869537353516
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58055022054513]": {
+            "Id": "Entity_[58055022054513]",
+            "Name": "Light_RL",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9172069229325435484
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8206619370733550280
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13793705696556064625,
+                    "Child Entity Order": [
+                        "Entity_[58042137152625]",
+                        "Entity_[58175281138801]",
+                        "Entity_[58132331465841]",
+                        "Entity_[58123741531249]",
+                        "Entity_[58149511335025]",
+                        "Entity_[58063611989105]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13161780626403192255
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2387504988228675296
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10169122181495623720
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9338808403578171831
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12707161379298739703
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10394210563839849370,
+                    "Parent Entity": "Entity_[2506590024219]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.6004743576049805,
+                            -0.8631248474121094,
+                            0.3072481155395508
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            0.00005122640868648887
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58063611989105]": {
+            "Id": "Entity_[58063611989105]",
+            "Name": "out_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 3.2603678703308105
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58055022054513]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.0298004150390625,
+                            0.1095888614654541,
+                            -0.012517035007476807
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            -89.99996948242188,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58067906956401]": {
+            "Id": "Entity_[58067906956401]",
+            "Name": "out_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 3.2603678703308105
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58050727087217]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.10072517395019531,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58072201923697]": {
+            "Id": "Entity_[58072201923697]",
+            "Name": "in_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58050727087217]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.03137779235839844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58085086825585]": {
+            "Id": "Entity_[58085086825585]",
+            "Name": "Light_FR",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9172069229325435484
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8206619370733550280
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13793705696556064625,
+                    "Child Entity Order": [
+                        "Entity_[58166691204209]",
+                        "Entity_[58183871073393]",
+                        "Entity_[58102266694769]",
+                        "Entity_[58033547218033]",
+                        "Entity_[58162396236913]",
+                        "Entity_[58153806302321]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13161780626403192255
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2387504988228675296
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10169122181495623720
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9338808403578171831
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12707161379298739703
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10394210563839849370,
+                    "Parent Entity": "Entity_[2506590024219]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.6045560836791992,
+                            0.8617401123046875,
+                            0.30724820494651794
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            179.99989318847656
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58089381792881]": {
+            "Id": "Entity_[58089381792881]",
+            "Name": "in_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58050727087217]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.16726231575012207,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58093676760177]": {
+            "Id": "Entity_[58093676760177]",
+            "Name": "out_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 3.2603678703308105
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58050727087217]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.0298004150390625,
+                            0.1095888614654541,
+                            -0.012517035007476807
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            -89.99996948242188,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58097971727473]": {
+            "Id": "Entity_[58097971727473]",
+            "Name": "in_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58188166040689]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.15564537048339844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58102266694769]": {
+            "Id": "Entity_[58102266694769]",
+            "Name": "in_FR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58085086825585]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.030210494995117188,
+                            0.03958702087402344,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.9998779296875,
+                            89.99988555908203,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58106561662065]": {
+            "Id": "Entity_[58106561662065]",
+            "Name": "out_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 7.071067810058594
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58188166040689]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.0298004150390625,
+                            0.1095888614654541,
+                            -0.012517035007476807
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            -89.99996948242188,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58119446563953]": {
+            "Id": "Entity_[58119446563953]",
+            "Name": "in_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58188166040689]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.16726231575012207,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58123741531249]": {
+            "Id": "Entity_[58123741531249]",
+            "Name": "in_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58055022054513]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.16726231575012207,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58132331465841]": {
+            "Id": "Entity_[58132331465841]",
+            "Name": "in_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58055022054513]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.03958702087402344,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58136626433137]": {
+            "Id": "Entity_[58136626433137]",
+            "Name": "in_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58050727087217]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.15564537048339844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58149511335025]": {
+            "Id": "Entity_[58149511335025]",
+            "Name": "out_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 3.2603678703308105
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58055022054513]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.10072517395019531,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58153806302321]": {
+            "Id": "Entity_[58153806302321]",
+            "Name": "out_FR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 7.071067810058594
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58085086825585]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.029800891876220703,
+                            0.10959053039550781,
+                            -0.012517035007476807
+                        ],
+                        "Rotate": [
+                            89.99962615966797,
+                            -89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58162396236913]": {
+            "Id": "Entity_[58162396236913]",
+            "Name": "out_FR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 7.071067810058594
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58085086825585]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.10072731971740723,
+                            -0.03713798522949219,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            89.99993133544922,
+                            0.00000965934304986149,
+                            0.0000048296788008883595
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58166691204209]": {
+            "Id": "Entity_[58166691204209]",
+            "Name": "in_FR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58085086825585]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.03137969970703125,
+                            -0.03713798522949219,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            -0.000004829676981898956,
+                            -0.00000965934304986149
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58170986171505]": {
+            "Id": "Entity_[58170986171505]",
+            "Name": "in_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58050727087217]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.03958702087402344,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58175281138801]": {
+            "Id": "Entity_[58175281138801]",
+            "Name": "in_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58055022054513]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.15564537048339844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58179576106097]": {
+            "Id": "Entity_[58179576106097]",
+            "Name": "in_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58188166040689]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.03958702087402344,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58183871073393]": {
+            "Id": "Entity_[58183871073393]",
+            "Name": "in_FR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58085086825585]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.15564560890197754,
+                            -0.03713798522949219,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            -0.000004829676981898956,
+                            -0.00000965934304986149
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58188166040689]": {
+            "Id": "Entity_[58188166040689]",
+            "Name": "Light_FL",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9172069229325435484
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8206619370733550280
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13793705696556064625,
+                    "Child Entity Order": [
+                        "Entity_[58192461007985]",
+                        "Entity_[58097971727473]",
+                        "Entity_[58179576106097]",
+                        "Entity_[58119446563953]",
+                        "Entity_[58196755975281]",
+                        "Entity_[58106561662065]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13161780626403192255
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2387504988228675296
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10169122181495623720
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9338808403578171831
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12707161379298739703
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10394210563839849370,
+                    "Parent Entity": "Entity_[2506590024219]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.5961513519287109,
+                            0.8684597015380859,
+                            0.30724820494651794
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            -89.99880981445313
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58192461007985]": {
+            "Id": "Entity_[58192461007985]",
+            "Name": "in_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58188166040689]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.03137779235839844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[58196755975281]": {
+            "Id": "Entity_[58196755975281]",
+            "Name": "out_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 7.071067810058594
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[58188166040689]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.10072517395019531,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            0.0,
+                            0.0
                         ]
                     }
                 }

--- a/Project/Assets/Importer/OTTO1500_Lifting_platform.prefab
+++ b/Project/Assets/Importer/OTTO1500_Lifting_platform.prefab
@@ -50,180 +50,6 @@
         }
     },
     "Entities": {
-        "Entity_[1067775980059]": {
-            "Id": "Entity_[1067775980059]",
-            "Name": "front",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                0.6802624464035034,
-                                0.6802624464035034,
-                                0.401022344827652
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 7.266918182373047
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        0.6802624464035034,
-                        0.6802624464035034,
-                        0.401022344827652,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[1196624998939]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.11914092302322388,
-                            0.04450613260269165,
-                            0.011720985174179077
-                        ],
-                        "Rotate": [
-                            -164.45391845703125,
-                            0.0000022315971364150755,
-                            0.00001003567194857169
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[1072070947355]": {
-            "Id": "Entity_[1072070947355]",
-            "Name": "left",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                0.6802624464035034,
-                                0.6802624464035034,
-                                0.401022344827652
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 7.266918182373047
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        0.6802624464035034,
-                        0.6802624464035034,
-                        0.401022344827652,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[1140790424091]",
-                    "Transform Data": {
-                        "Translate": [
-                            -0.037393927574157715,
-                            -0.08997642993927002,
-                            -0.009903758764266968
-                        ],
-                        "Rotate": [
-                            178.7519073486328,
-                            24.367582321166992,
-                            -86.97740936279297
-                        ]
-                    }
-                }
-            }
-        },
         "Entity_[1076365914651]": {
             "Id": "Entity_[1076365914651]",
             "Name": "wheel_CR_visual",
@@ -238,7 +64,7 @@
                                     "guid": "{4294F702-5FCE-5C6A-9FE5-8125292ECB62}",
                                     "subId": 277864421
                                 },
-                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_center.azmodel"
+                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_center.stl.azmodel"
                             }
                         }
                     }
@@ -262,6 +88,29 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 11803937763819406048
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 10017372342351126242,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            },
+                                            "assetHint": "materials/presets/macbeth/24_black_2-0_1-50d.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -294,93 +143,6 @@
                 }
             }
         },
-        "Entity_[1080660881947]": {
-            "Id": "Entity_[1080660881947]",
-            "Name": "rear",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                1.0,
-                                0.09279011189937592,
-                                0.006515602581202984
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 4.728076934814453
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        1.0,
-                        0.09279011189937592,
-                        0.006515602581202984,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[1200919966235]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.1034647524356842,
-                            -0.20430141687393188,
-                            0.011321723461151123
-                        ],
-                        "Rotate": [
-                            162.54373168945313,
-                            -0.6320992112159729,
-                            -4.677469730377197
-                        ]
-                    }
-                }
-            }
-        },
         "Entity_[1084955849243]": {
             "Id": "Entity_[1084955849243]",
             "Name": "lift_module_visual",
@@ -395,7 +157,7 @@
                                     "guid": "{7D3B18C1-3C0D-5A3B-AD2B-1E18588A572A}",
                                     "subId": 277442517
                                 },
-                                "assetHint": "prefabs/otto1500_platform/otto1500_platfrom_b/default_platformb_bf9727f7_316a_5ef8_aac4_e2811b23509d_.azmodel"
+                                "assetHint": "prefabs/otto1500_platform/otto1500_platfrom_b/default_platformb_bf9727f7_316a_5ef8_aac4_e2811b23509d_.fbx.azmodel"
                             }
                         }
                     }
@@ -419,6 +181,28 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 11826088549528110714
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 5077680438282041446,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2534313805
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{5C0474CE-8FE0-5457-806D-0FBCD15DC5FB}"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorNonUniformScaleComponent": {
                     "$type": "EditorNonUniformScaleComponent",
@@ -481,12 +265,10 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 8264695973947253758,
                     "Child Entity Order": [
-                        "Entity_[6935996328295]",
-                        "Entity_[36440571358490]",
-                        "Entity_[1140790424091]",
-                        "Entity_[1196624998939]",
-                        "Entity_[1200919966235]",
-                        "Entity_[1115020620315]"
+                        "Entity_[60378599361649]",
+                        "Entity_[60404369165425]",
+                        "Entity_[60391484263537]",
+                        "Entity_[60412959100017]"
                     ]
                 },
                 "EditorInspectorComponent": {
@@ -580,93 +362,6 @@
                             0.0,
                             0.0,
                             -90.0
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[1093545783835]": {
-            "Id": "Entity_[1093545783835]",
-            "Name": "front",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                0.6802624464035034,
-                                0.6802624464035034,
-                                0.401022344827652
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 7.266918182373047
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        0.6802624464035034,
-                        0.6802624464035034,
-                        0.401022344827652,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[1140790424091]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.11914092302322388,
-                            0.04450613260269165,
-                            0.011720985174179077
-                        ],
-                        "Rotate": [
-                            -164.45391845703125,
-                            0.0000022315971364150755,
-                            0.00001003567194857169
                         ]
                     }
                 }
@@ -1025,93 +720,6 @@
                 }
             }
         },
-        "Entity_[1106430685723]": {
-            "Id": "Entity_[1106430685723]",
-            "Name": "left",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                1.0,
-                                0.09279011189937592,
-                                0.006515602581202984
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 4.728076934814453
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        1.0,
-                        0.09279011189937592,
-                        0.006515602581202984,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[1115020620315]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.029989778995513916,
-                            -0.12438899278640747,
-                            -0.0036117732524871826
-                        ],
-                        "Rotate": [
-                            179.8093719482422,
-                            41.04417037963867,
-                            -87.87556457519531
-                        ]
-                    }
-                }
-            }
-        },
         "Entity_[1110725653019]": {
             "Id": "Entity_[1110725653019]",
             "Name": "base_link",
@@ -1230,6 +838,8 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 10591773995143986513,
                     "Child Entity Order": [
+                        "Entity_[6935996328295]",
+                        "Entity_[36440571358490]",
                         "Entity_[1097840751131]",
                         "Entity_[1127905522203]",
                         "Entity_[1102135718427]",
@@ -1296,6 +906,47 @@
                                 "guid": "{7D2DCE6D-3A85-5781-9EBB-3CA0D979919D}"
                             },
                             "assetHint": "prefabs/otto1500/scripts/otto1500robot_inputs.inputbindings"
+                        }
+                    }
+                },
+                "LightController": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 462972920181002566,
+                    "m_template": {
+                        "$type": "LightController",
+                        "configuration": {
+                            "LightEntityIdList": [
+                                "Entity_[60305584917617]",
+                                "Entity_[60344239623281]",
+                                "Entity_[60352829557873]",
+                                "Entity_[60335649688689]",
+                                "Entity_[60417254067313]",
+                                "Entity_[60327059754097]",
+                                "Entity_[60301289950321]",
+                                "Entity_[60408664132721]",
+                                "Entity_[60288405048433]",
+                                "Entity_[60258340277361]",
+                                "Entity_[60266930211953]",
+                                "Entity_[60348534590577]",
+                                "Entity_[60318469819505]",
+                                "Entity_[60395779230833]",
+                                "Entity_[60249750342769]",
+                                "Entity_[60262635244657]",
+                                "Entity_[60443023871089]",
+                                "Entity_[60271225179249]",
+                                "Entity_[60309879884913]",
+                                "Entity_[60279815113841]",
+                                "Entity_[60339944655985]",
+                                "Entity_[60370009427057]",
+                                "Entity_[60254045310065]",
+                                "Entity_[60382894328945]"
+                            ],
+                            "TopicConfiguration": {
+                                "Topic": "color",
+                                "QoS": {
+                                    "Reliability": 1
+                                }
+                            }
                         }
                     }
                 },
@@ -1374,60 +1025,6 @@
                 }
             }
         },
-        "Entity_[1115020620315]": {
-            "Id": "Entity_[1115020620315]",
-            "Name": "lights_rear_left",
-            "Components": {
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 7587756992547510330
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 4398300183131950651
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 8623555211141947147,
-                    "Child Entity Order": [
-                        "Entity_[1106430685723]",
-                        "Entity_[1175150162459]"
-                    ]
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 2691391330247274228
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 11157075607780090074
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 5540099253879459478
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 17249713216533827311
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 6932711339470502100
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 5215931359061447226,
-                    "Parent Entity": "Entity_[1089250816539]",
-                    "Transform Data": {
-                        "Translate": [
-                            -0.6733757257461548,
-                            -0.7120498418807983,
-                            0.3009859621524811
-                        ]
-                    }
-                }
-            }
-        },
         "Entity_[1119315587611]": {
             "Id": "Entity_[1119315587611]",
             "Name": "wheel_RL_visual",
@@ -1442,7 +1039,7 @@
                                     "guid": "{1F07ABE6-C6BE-5AA9-BC0D-2A28FDA28639}",
                                     "subId": 268916636
                                 },
-                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_front_rear.azmodel"
+                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_front_rear.stl.azmodel"
                             }
                         }
                     }
@@ -1466,6 +1063,29 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 5769824488783122165
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 12069188154593434433,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            },
+                                            "assetHint": "materials/presets/macbeth/24_black_2-0_1-50d.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -1512,7 +1132,7 @@
                                     "guid": "{7D3B18C1-3C0D-5A3B-AD2B-1E18588A572A}",
                                     "subId": 281546809
                                 },
-                                "assetHint": "prefabs/otto1500_platform/otto1500_platfrom_b/default_platformb_9459dae0_4534_511d_82fd_b3d3d75d79c3_.azmodel"
+                                "assetHint": "prefabs/otto1500_platform/otto1500_platfrom_b/default_platformb_9459dae0_4534_511d_82fd_b3d3d75d79c3_.fbx.azmodel"
                             }
                         }
                     }
@@ -1536,6 +1156,28 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 4596576050705670734
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 14990683314745866387,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2534313805
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{5C0474CE-8FE0-5457-806D-0FBCD15DC5FB}"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -1968,60 +1610,6 @@
                 }
             }
         },
-        "Entity_[1140790424091]": {
-            "Id": "Entity_[1140790424091]",
-            "Name": "lights_front_left",
-            "Components": {
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 7587756992547510330
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 4398300183131950651
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 8623555211141947147,
-                    "Child Entity Order": [
-                        "Entity_[1093545783835]",
-                        "Entity_[1072070947355]"
-                    ]
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 2691391330247274228
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 11157075607780090074
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 5540099253879459478
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 17249713216533827311
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 6932711339470502100
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 5215931359061447226,
-                    "Parent Entity": "Entity_[1089250816539]",
-                    "Transform Data": {
-                        "Translate": [
-                            -0.6133816838264465,
-                            0.8832632899284363,
-                            0.30103132128715515
-                        ]
-                    }
-                }
-            }
-        },
         "Entity_[1145085391387]": {
             "Id": "Entity_[1145085391387]",
             "Name": "wheel_CR",
@@ -2175,7 +1763,7 @@
                                     "guid": "{1F07ABE6-C6BE-5AA9-BC0D-2A28FDA28639}",
                                     "subId": 268916636
                                 },
-                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_front_rear.azmodel"
+                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_front_rear.stl.azmodel"
                             }
                         }
                     }
@@ -2199,6 +1787,29 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 13775672294355917038
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 16558182839601964979,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            },
+                                            "assetHint": "materials/presets/macbeth/24_black_2-0_1-50d.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -2245,7 +1856,7 @@
                                     "guid": "{4294F702-5FCE-5C6A-9FE5-8125292ECB62}",
                                     "subId": 277864421
                                 },
-                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_center.azmodel"
+                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_center.stl.azmodel"
                             }
                         }
                     }
@@ -2269,6 +1880,29 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 12358837627041604096
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 8222503397371086439,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            },
+                                            "assetHint": "materials/presets/macbeth/24_black_2-0_1-50d.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -2539,7 +2173,7 @@
                                     "guid": "{7D3B18C1-3C0D-5A3B-AD2B-1E18588A572A}",
                                     "subId": 279277493
                                 },
-                                "assetHint": "prefabs/otto1500_platform/otto1500_platfrom_b/default_platformb_a41277ae_61fd_5b47_9b15_8b4f264e04f2_.azmodel"
+                                "assetHint": "prefabs/otto1500_platform/otto1500_platfrom_b/default_platformb_a41277ae_61fd_5b47_9b15_8b4f264e04f2_.fbx.azmodel"
                             }
                         }
                     }
@@ -2563,6 +2197,28 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 15890985072082828721
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 8689921559599501368,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2534313805
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{5C0474CE-8FE0-5457-806D-0FBCD15DC5FB}"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -2725,180 +2381,6 @@
                 }
             }
         },
-        "Entity_[1175150162459]": {
-            "Id": "Entity_[1175150162459]",
-            "Name": "rear",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                1.0,
-                                0.09279011189937592,
-                                0.006515602581202984
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 4.728076934814453
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        1.0,
-                        0.09279011189937592,
-                        0.006515602581202984,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[1115020620315]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.19255352020263672,
-                            -0.20787888765335083,
-                            0.011416405439376831
-                        ],
-                        "Rotate": [
-                            162.54373168945313,
-                            -0.6320992112159729,
-                            -4.677469730377197
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[1179445129755]": {
-            "Id": "Entity_[1179445129755]",
-            "Name": "right",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                1.0,
-                                0.09279011189937592,
-                                0.006515602581202984
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 4.728076934814453
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        1.0,
-                        0.09279011189937592,
-                        0.006515602581202984,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[1200919966235]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.2754446864128113,
-                            -0.10337775945663452,
-                            0.014488428831100464
-                        ],
-                        "Rotate": [
-                            179.8093719482422,
-                            41.04417037963867,
-                            -87.87556457519531
-                        ]
-                    }
-                }
-            }
-        },
         "Entity_[1188035064347]": {
             "Id": "Entity_[1188035064347]",
             "Name": "wheel_FL_visual",
@@ -2913,7 +2395,7 @@
                                     "guid": "{1F07ABE6-C6BE-5AA9-BC0D-2A28FDA28639}",
                                     "subId": 268916636
                                 },
-                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_front_rear.azmodel"
+                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_front_rear.stl.azmodel"
                             }
                         }
                     }
@@ -2937,6 +2419,29 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 11325795580269188509
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 7938628779983185955,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            },
+                                            "assetHint": "materials/presets/macbeth/24_black_2-0_1-50d.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -2983,7 +2488,7 @@
                                     "guid": "{1F07ABE6-C6BE-5AA9-BC0D-2A28FDA28639}",
                                     "subId": 268916636
                                 },
-                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_front_rear.azmodel"
+                                "assetHint": "assets/urdfimporter/2361167171_otto1500.urdf/otto1500_wheel_front_rear.stl.azmodel"
                             }
                         }
                     }
@@ -3007,6 +2512,28 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 14673788159543010410
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 1208430239112228355,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2084814471
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{1D83625A-4016-58F0-A94A-13B92B19F5B5}"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -3034,201 +2561,6 @@
                             0.0,
                             0.0,
                             89.99999237060547
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[1196624998939]": {
-            "Id": "Entity_[1196624998939]",
-            "Name": "lights_front_right",
-            "Components": {
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 7587756992547510330
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 4398300183131950651
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 8623555211141947147,
-                    "Child Entity Order": [
-                        "Entity_[1067775980059]",
-                        "Entity_[1205214933531]"
-                    ]
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 2691391330247274228
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 11157075607780090074
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 5540099253879459478
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 17249713216533827311
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 6932711339470502100
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 5215931359061447226,
-                    "Parent Entity": "Entity_[1089250816539]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.3645870089530945,
-                            0.8836016058921814,
-                            0.3009859621524811
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[1200919966235]": {
-            "Id": "Entity_[1200919966235]",
-            "Name": "lights_rear_right",
-            "Components": {
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 7587756992547510330
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 4398300183131950651
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 8623555211141947147,
-                    "Child Entity Order": [
-                        "Entity_[1080660881947]",
-                        "Entity_[1179445129755]"
-                    ]
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 2691391330247274228
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 11157075607780090074
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 5540099253879459478
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 17249713216533827311
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 6932711339470502100
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 5215931359061447226,
-                    "Parent Entity": "Entity_[1089250816539]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.3645869791507721,
-                            -0.7120500802993774,
-                            0.3009859621524811
-                        ]
-                    }
-                }
-            }
-        },
-        "Entity_[1205214933531]": {
-            "Id": "Entity_[1205214933531]",
-            "Name": "right",
-            "Components": {
-                "AZ::Render::EditorAreaLightComponent": {
-                    "$type": "AZ::Render::EditorAreaLightComponent",
-                    "Id": 4027891657050258307,
-                    "Controller": {
-                        "Configuration": {
-                            "LightType": 4,
-                            "Color": [
-                                0.6802624464035034,
-                                0.6802624464035034,
-                                0.401022344827652
-                            ],
-                            "Intensity": 8.0,
-                            "AttenuationRadius": 7.266918182373047
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 8271327546106839693
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 12438543476310294471
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 7931936095162389806
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 12296913873222022464
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 15701788781948922620
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11083459701262423
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1618015645431603199
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18439273685567816340
-                },
-                "LmbrCentral::EditorQuadShapeComponent": {
-                    "$type": "LmbrCentral::EditorQuadShapeComponent",
-                    "Id": 8298109831893415645,
-                    "ShapeColor": [
-                        0.6802624464035034,
-                        0.6802624464035034,
-                        0.401022344827652,
-                        1.0
-                    ],
-                    "QuadShape": {
-                        "Configuration": {
-                            "Width": 0.30000001192092896,
-                            "Height": 0.0010000000474974513
-                        }
-                    }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 824878579940915241,
-                    "Parent Entity": "Entity_[1196624998939]",
-                    "Transform Data": {
-                        "Translate": [
-                            0.2821972072124481,
-                            -0.08989912271499634,
-                            0.021053224802017212
-                        ],
-                        "Rotate": [
-                            -178.98049926757813,
-                            43.831703186035156,
-                            -88.7185287475586
                         ]
                     }
                 }
@@ -3304,12 +2636,2313 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2266808635572036430,
+                    "Parent Entity": "Entity_[1110725653019]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.8600006103515625,
+                            -0.5999999046325684,
+                            0.09999998658895493
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            -89.99999237060547
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60249750342769]": {
+            "Id": "Entity_[60249750342769]",
+            "Name": "in_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60391484263537]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.03958702087402344,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60254045310065]": {
+            "Id": "Entity_[60254045310065]",
+            "Name": "out_FR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 7.071067810058594
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60412959100017]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.10072731971740723,
+                            -0.03713798522949219,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            89.99993133544922,
+                            0.00000965934304986149,
+                            0.0000048296788008883595
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60258340277361]": {
+            "Id": "Entity_[60258340277361]",
+            "Name": "in_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60404369165425]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.16726231575012207,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60262635244657]": {
+            "Id": "Entity_[60262635244657]",
+            "Name": "in_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60391484263537]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.16726231575012207,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60266930211953]": {
+            "Id": "Entity_[60266930211953]",
+            "Name": "out_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 3.2603678703308105
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60404369165425]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.10072517395019531,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60271225179249]": {
+            "Id": "Entity_[60271225179249]",
+            "Name": "out_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 7.071067810058594
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60391484263537]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.0298004150390625,
+                            0.1095888614654541,
+                            -0.012517035007476807
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            -89.99996948242188,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60279815113841]": {
+            "Id": "Entity_[60279815113841]",
+            "Name": "in_FR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60412959100017]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.15564560890197754,
+                            -0.03713798522949219,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            -0.000004829676981898956,
+                            -0.00000965934304986149
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60288405048433]": {
+            "Id": "Entity_[60288405048433]",
+            "Name": "in_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60404369165425]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.03958702087402344,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60301289950321]": {
+            "Id": "Entity_[60301289950321]",
+            "Name": "in_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60404369165425]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.03137779235839844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60305584917617]": {
+            "Id": "Entity_[60305584917617]",
+            "Name": "in_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60378599361649]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.03137779235839844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60309879884913]": {
+            "Id": "Entity_[60309879884913]",
+            "Name": "in_FR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60412959100017]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.03137969970703125,
+                            -0.03713798522949219,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            -0.000004829676981898956,
+                            -0.00000965934304986149
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60318469819505]": {
+            "Id": "Entity_[60318469819505]",
+            "Name": "in_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60391484263537]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.03137779235839844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60327059754097]": {
+            "Id": "Entity_[60327059754097]",
+            "Name": "out_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 3.2603678703308105
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60378599361649]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.0298004150390625,
+                            0.1095888614654541,
+                            -0.012517035007476807
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            -89.99996948242188,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60335649688689]": {
+            "Id": "Entity_[60335649688689]",
+            "Name": "in_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60378599361649]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.16726231575012207,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60339944655985]": {
+            "Id": "Entity_[60339944655985]",
+            "Name": "in_FR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60412959100017]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.030210494995117188,
+                            0.03958702087402344,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.9998779296875,
+                            89.99988555908203,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60344239623281]": {
+            "Id": "Entity_[60344239623281]",
+            "Name": "in_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60378599361649]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.15564537048339844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60348534590577]": {
+            "Id": "Entity_[60348534590577]",
+            "Name": "out_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 3.2603678703308105
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60404369165425]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.0298004150390625,
+                            0.1095888614654541,
+                            -0.012517035007476807
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            -89.99996948242188,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60352829557873]": {
+            "Id": "Entity_[60352829557873]",
+            "Name": "in_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60378599361649]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021240234375,
+                            0.03958702087402344,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.99994659423828,
+                            89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60370009427057]": {
+            "Id": "Entity_[60370009427057]",
+            "Name": "in_FR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60412959100017]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.03021073341369629,
+                            0.16726303100585938,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -89.9998779296875,
+                            89.99988555908203,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60378599361649]": {
+            "Id": "Entity_[60378599361649]",
+            "Name": "Light_RR",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9172069229325435484
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8206619370733550280
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13793705696556064625,
+                    "Child Entity Order": [
+                        "Entity_[60305584917617]",
+                        "Entity_[60344239623281]",
+                        "Entity_[60352829557873]",
+                        "Entity_[60335649688689]",
+                        "Entity_[60417254067313]",
+                        "Entity_[60327059754097]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13161780626403192255
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2387504988228675296
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10169122181495623720
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9338808403578171831
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12707161379298739703
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10394210563839849370,
                     "Parent Entity": "Entity_[1089250816539]",
                     "Transform Data": {
                         "Translate": [
-                            0.6000000238418579,
-                            -0.8600000143051147,
-                            0.09999999403953552
+                            0.5959758758544922,
+                            -0.8714046478271484,
+                            0.3072481155395508
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            89.9986801147461
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60382894328945]": {
+            "Id": "Entity_[60382894328945]",
+            "Name": "out_FR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 7.071067810058594
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60412959100017]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.029800891876220703,
+                            0.10959053039550781,
+                            -0.012517035007476807
+                        ],
+                        "Rotate": [
+                            89.99962615966797,
+                            -89.99994659423828,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60391484263537]": {
+            "Id": "Entity_[60391484263537]",
+            "Name": "Light_FL",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9172069229325435484
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8206619370733550280
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13793705696556064625,
+                    "Child Entity Order": [
+                        "Entity_[60318469819505]",
+                        "Entity_[60395779230833]",
+                        "Entity_[60249750342769]",
+                        "Entity_[60262635244657]",
+                        "Entity_[60443023871089]",
+                        "Entity_[60271225179249]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13161780626403192255
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2387504988228675296
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10169122181495623720
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9338808403578171831
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12707161379298739703
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10394210563839849370,
+                    "Parent Entity": "Entity_[1089250816539]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.5961513519287109,
+                            0.8684597015380859,
+                            0.3072481155395508
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            -89.99878692626953
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60395779230833]": {
+            "Id": "Entity_[60395779230833]",
+            "Name": "in_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60391484263537]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.15564537048339844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60404369165425]": {
+            "Id": "Entity_[60404369165425]",
+            "Name": "Light_RL",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9172069229325435484
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8206619370733550280
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13793705696556064625,
+                    "Child Entity Order": [
+                        "Entity_[60301289950321]",
+                        "Entity_[60408664132721]",
+                        "Entity_[60288405048433]",
+                        "Entity_[60258340277361]",
+                        "Entity_[60266930211953]",
+                        "Entity_[60348534590577]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13161780626403192255
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2387504988228675296
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10169122181495623720
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9338808403578171831
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12707161379298739703
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10394210563839849370,
+                    "Parent Entity": "Entity_[1089250816539]",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.6004743576049805,
+                            -0.8631267547607422,
+                            0.3072480261325836
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            0.00005122640868648887
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60408664132721]": {
+            "Id": "Entity_[60408664132721]",
+            "Name": "in_RL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 0.10000000149011612,
+                            "AttenuationRadiusMode": 0,
+                            "AttenuationRadius": 0.08500000089406967
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.14000000059604645,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60404369165425]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.15564537048339844,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            -90.00000762939453,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60412959100017]": {
+            "Id": "Entity_[60412959100017]",
+            "Name": "Light_FR",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9172069229325435484
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8206619370733550280
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13793705696556064625,
+                    "Child Entity Order": [
+                        "Entity_[60309879884913]",
+                        "Entity_[60279815113841]",
+                        "Entity_[60339944655985]",
+                        "Entity_[60370009427057]",
+                        "Entity_[60254045310065]",
+                        "Entity_[60382894328945]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13161780626403192255
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2387504988228675296
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10169122181495623720
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9338808403578171831
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12707161379298739703
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10394210563839849370,
+                    "Parent Entity": "Entity_[1089250816539]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.604555606842041,
+                            0.8617401123046875,
+                            0.3072481155395508
+                        ],
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            179.99989318847656
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60417254067313]": {
+            "Id": "Entity_[60417254067313]",
+            "Name": "out_RR",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Color": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 3.2603678703308105
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60378599361649]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.10072517395019531,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[60443023871089]": {
+            "Id": "Entity_[60443023871089]",
+            "Name": "out_FL",
+            "Components": {
+                "AZ::Render::EditorAreaLightComponent": {
+                    "$type": "AZ::Render::EditorAreaLightComponent",
+                    "Id": 1785973739929303350,
+                    "Controller": {
+                        "Configuration": {
+                            "LightType": 4,
+                            "Intensity": 5.0,
+                            "AttenuationRadius": 7.071067810058594
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9674813848600866137
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16233921723394238903
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16687462048376832276
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10667933295669397881
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6759913094008271528
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1338086874615879553
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15993105608309907256
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15762540797896440595
+                },
+                "LmbrCentral::EditorQuadShapeComponent": {
+                    "$type": "LmbrCentral::EditorQuadShapeComponent",
+                    "Id": 3162277983435690611,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "QuadShape": {
+                        "Configuration": {
+                            "Width": 0.25,
+                            "Height": 0.009999999776482582
+                        }
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11625144197564318659,
+                    "Parent Entity": "Entity_[60391484263537]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.10072517395019531,
+                            -0.03713703155517578,
+                            -0.012516915798187256
+                        ],
+                        "Rotate": [
+                            89.99994659423828,
+                            0.0,
+                            0.0
                         ]
                     }
                 }
@@ -3385,17 +5018,17 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2266808635572036430,
-                    "Parent Entity": "Entity_[1089250816539]",
+                    "Parent Entity": "Entity_[1110725653019]",
                     "Transform Data": {
                         "Translate": [
-                            -0.5999999046325684,
-                            0.8599998950958252,
-                            0.09999999403953552
+                            0.8600006103515625,
+                            0.5999999046325684,
+                            0.09999998658895493
                         ],
                         "Rotate": [
                             0.0,
                             0.0,
-                            180.0
+                            89.99998474121094
                         ]
                     }
                 }

--- a/Project/Assets/Importer/Otto1500_Otto_1500_Lights_Back.material
+++ b/Project/Assets/Importer/Otto1500_Otto_1500_Lights_Back.material
@@ -3,13 +3,6 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "otto_textures/Otto_1500_Lights_Back_BaseColor.png",
-        "emissive.color": [
-            0.8104981780052185,
-            0.14013886451721191,
-            0.0,
-            1.0
-        ],
-        "emissive.enable": true,
         "emissive.textureMap": "otto_textures/Otto_1500_Lights_Back_Emmisive.png",
         "metallic.textureMap": "otto_textures/Otto_1500_Lights_Back_Metallic.png",
         "opacity.factor": 1.0,

--- a/Project/Assets/Importer/Otto1500_Otto_1500_Lights_Front.material
+++ b/Project/Assets/Importer/Otto1500_Otto_1500_Lights_Front.material
@@ -3,7 +3,6 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "otto_textures/Otto_1500_Lights_Front_BaseColor.png",
-        "emissive.enable": true,
         "emissive.intensity": 3.680000066757202,
         "emissive.textureMap": "otto_textures/Otto_1500_Lights_Front_Emmisive.png",
         "metallic.textureMap": "otto_textures/Otto_1500_Lights_Front_Metallic.png",

--- a/Project/Assets/Importer/Otto1500_Otto_1500_Lights_Side.material
+++ b/Project/Assets/Importer/Otto1500_Otto_1500_Lights_Side.material
@@ -3,7 +3,6 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "otto_textures/Otto_1500_Lights_Side_BaseColor.png",
-        "emissive.enable": true,
         "emissive.textureMap": "otto_textures/Otto_1500_Lights_Side_Emmisive.png",
         "metallic.textureMap": "otto_textures/Otto_1500_Lights_Side_Metallic.png",
         "opacity.factor": 1.0,

--- a/Project/Prefabs/OTTO1500_Platform/Otto1500_Platfrom_B/PlatformB_Platfrom_B.material
+++ b/Project/Prefabs/OTTO1500_Platform/Otto1500_Platfrom_B/PlatformB_Platfrom_B.material
@@ -19,9 +19,8 @@
         "normal.textureMap": "Textures/Platform_B_Normal.png",
         "opacity.factor": 1.0,
         "roughness.factor": 0.4000000059604645,
-        "roughness.lowerBound": 0.5,
         "roughness.textureMap": "Textures/Platform_B_Roughness.png",
-        "roughness.upperBound": 0.8999999761581421,
+        "roughness.upperBound": 0.75,
         "specularF0.textureMap": "Textures/Platform_B_Specular.png"
     }
 }

--- a/Project/Prefabs/OTTO600/OTTO600.prefab
+++ b/Project/Prefabs/OTTO600/OTTO600.prefab
@@ -123,11 +123,11 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15602598512040496450,
-                    "Parent Entity": "Entity_[415091819019]",
+                    "Parent Entity": "Entity_[376437113355]",
                     "Transform Data": {
                         "Translate": [
-                            0.5297555923461914,
-                            0.40851765871047974,
+                            0.529754638671875,
+                            0.40851783752441406,
                             0.18674802780151367
                         ],
                         "Rotate": [
@@ -387,11 +387,11 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15602598512040496450,
-                    "Parent Entity": "Entity_[415091819019]",
+                    "Parent Entity": "Entity_[376437113355]",
                     "Transform Data": {
                         "Translate": [
                             -0.5857334136962891,
-                            -0.40281927585601807,
+                            -0.4028191566467285,
                             0.1852550506591797
                         ],
                         "Rotate": [
@@ -2577,10 +2577,10 @@
                         "Configuration": {
                             "ModelAsset": {
                                 "assetId": {
-                                    "guid": "{8EC189BD-0C14-5684-BF63-D1E6A4C1A8CE}",
-                                    "subId": 268640466
+                                    "guid": "{D0C0E57A-0068-5269-B3A0-A827DD4090D9}",
+                                    "subId": 274705241
                                 },
-                                "assetHint": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.azmodel"
+                                "assetHint": "prefabs/otto600/default_otto600_1656cfa9_69f2_5d41_85db_1a4fcba4b0f5_.fbx.azmodel"
                             }
                         }
                     }
@@ -2620,7 +2620,10 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 5603363823810660091,
-                    "Parent Entity": "Entity_[367847178763]"
+                    "Parent Entity": "Entity_[367847178763]",
+                    "Transform Data": {
+                        "UniformScale": 0.009999999776482582
+                    }
                 }
             }
         },
@@ -3042,14 +3045,16 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 15191659956461039518,
                     "Child Entity Order": [
-                        "Entity_[479516328459]",
+                        "Entity_[187685058540532]",
+                        "Entity_[207905764570100]",
                         "Entity_[402206917131]",
+                        "Entity_[479516328459]",
                         "Entity_[449451557387]",
                         "Entity_[389322015243]",
                         "Entity_[462336459275]",
                         "Entity_[372142146059]",
-                        "Entity_[415091819019]",
                         "Entity_[367847178763]",
+                        "Entity_[415091819019]",
                         "Entity_[24172719660011]"
                     ]
                 },
@@ -3306,10 +3311,10 @@
                         "Configuration": {
                             "ModelAsset": {
                                 "assetId": {
-                                    "guid": "{8EC189BD-0C14-5684-BF63-D1E6A4C1A8CE}",
-                                    "subId": 268640466
+                                    "guid": "{D0C0E57A-0068-5269-B3A0-A827DD4090D9}",
+                                    "subId": 274705241
                                 },
-                                "assetHint": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.azmodel"
+                                "assetHint": "prefabs/otto600/default_otto600_1656cfa9_69f2_5d41_85db_1a4fcba4b0f5_.fbx.azmodel"
                             }
                         }
                     }
@@ -3349,7 +3354,10 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 6159509585614812483,
-                    "Parent Entity": "Entity_[479516328459]"
+                    "Parent Entity": "Entity_[479516328459]",
+                    "Transform Data": {
+                        "UniformScale": 0.009999999776482582
+                    }
                 }
             }
         },
@@ -3862,21 +3870,6 @@
             "Id": "Entity_[415091819019]",
             "Name": "base_link_visual",
             "Components": {
-                "AZ::Render::EditorMeshComponent": {
-                    "$type": "AZ::Render::EditorMeshComponent",
-                    "Id": 3270945428654281390,
-                    "Controller": {
-                        "Configuration": {
-                            "ModelAsset": {
-                                "assetId": {
-                                    "guid": "{D0C0E57A-0068-5269-B3A0-A827DD4090D9}",
-                                    "subId": 273650306
-                                },
-                                "assetHint": "prefabs/otto600/otto600.fbx.azmodel"
-                            }
-                        }
-                    }
-                },
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 544057150285502687
@@ -3889,12 +3882,11 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 1235514382533876233,
                     "Child Entity Order": [
+                        "Entity_[53867428940913]",
                         "Entity_[470926393867]",
                         "Entity_[210679758454008]",
                         "Entity_[210739887996152]",
-                        "Entity_[210838672243960]",
-                        "Entity_[187685058540532]",
-                        "Entity_[207905764570100]"
+                        "Entity_[210838672243960]"
                     ]
                 },
                 "EditorInspectorComponent": {
@@ -3904,68 +3896,6 @@
                 "EditorLockComponent": {
                     "$type": "EditorLockComponent",
                     "Id": 15121884590352162101
-                },
-                "EditorMaterialComponent": {
-                    "$type": "EditorMaterialComponent",
-                    "Id": 13570587953096653072,
-                    "Controller": {
-                        "Configuration": {
-                            "materials": [
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 48421206
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{73AD6398-0854-5467-839E-7E0AF9A25146}"
-                                            },
-                                            "assetHint": "prefabs/otto600/otto600_emission03.azmaterial"
-                                        }
-                                    }
-                                },
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 114592210
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{BC11CF39-9966-5086-BAAA-67410FCC66B8}"
-                                            },
-                                            "assetHint": "prefabs/otto600/otto600_emission02.azmaterial"
-                                        }
-                                    }
-                                },
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 1355161694
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{8505748C-1422-57A0-BA40-5E817F0EBBCA}"
-                                            },
-                                            "assetHint": "prefabs/otto600/otto600_emission01.azmaterial"
-                                        }
-                                    }
-                                },
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 3373457715
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{A39B27FE-9F92-52CA-A9A5-E5A707BDF6AA}"
-                                            },
-                                            "assetHint": "prefabs/otto600/otto600_otto600.azmaterial"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    }
                 },
                 "EditorOnlyEntityComponent": {
                     "$type": "EditorOnlyEntityComponent",
@@ -3997,10 +3927,10 @@
                         "Configuration": {
                             "ModelAsset": {
                                 "assetId": {
-                                    "guid": "{8EC189BD-0C14-5684-BF63-D1E6A4C1A8CE}",
-                                    "subId": 268640466
+                                    "guid": "{D0C0E57A-0068-5269-B3A0-A827DD4090D9}",
+                                    "subId": 274705241
                                 },
-                                "assetHint": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.azmodel"
+                                "assetHint": "prefabs/otto600/default_otto600_1656cfa9_69f2_5d41_85db_1a4fcba4b0f5_.fbx.azmodel"
                             }
                         }
                     }
@@ -4040,7 +3970,10 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 12493637505676290818,
-                    "Parent Entity": "Entity_[462336459275]"
+                    "Parent Entity": "Entity_[462336459275]",
+                    "Transform Data": {
+                        "UniformScale": 0.009999999776482582
+                    }
                 }
             }
         },
@@ -4055,10 +3988,10 @@
                         "Configuration": {
                             "ModelAsset": {
                                 "assetId": {
-                                    "guid": "{8EC189BD-0C14-5684-BF63-D1E6A4C1A8CE}",
-                                    "subId": 268640466
+                                    "guid": "{D0C0E57A-0068-5269-B3A0-A827DD4090D9}",
+                                    "subId": 274705241
                                 },
-                                "assetHint": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.azmodel"
+                                "assetHint": "prefabs/otto600/default_otto600_1656cfa9_69f2_5d41_85db_1a4fcba4b0f5_.fbx.azmodel"
                             }
                         }
                     }
@@ -4098,7 +4031,10 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9733178881028597695,
-                    "Parent Entity": "Entity_[389322015243]"
+                    "Parent Entity": "Entity_[389322015243]",
+                    "Transform Data": {
+                        "UniformScale": 0.009999999776482582
+                    }
                 }
             }
         },
@@ -4356,10 +4292,10 @@
                         "Configuration": {
                             "ModelAsset": {
                                 "assetId": {
-                                    "guid": "{8EC189BD-0C14-5684-BF63-D1E6A4C1A8CE}",
-                                    "subId": 268640466
+                                    "guid": "{D0C0E57A-0068-5269-B3A0-A827DD4090D9}",
+                                    "subId": 274705241
                                 },
-                                "assetHint": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.azmodel"
+                                "assetHint": "prefabs/otto600/default_otto600_1656cfa9_69f2_5d41_85db_1a4fcba4b0f5_.fbx.azmodel"
                             }
                         }
                     }
@@ -4399,7 +4335,10 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 17205227778608021128,
-                    "Parent Entity": "Entity_[449451557387]"
+                    "Parent Entity": "Entity_[449451557387]",
+                    "Transform Data": {
+                        "UniformScale": 0.009999999776482582
+                    }
                 }
             }
         },
@@ -4865,10 +4804,10 @@
                         "Configuration": {
                             "ModelAsset": {
                                 "assetId": {
-                                    "guid": "{8EC189BD-0C14-5684-BF63-D1E6A4C1A8CE}",
-                                    "subId": 268640466
+                                    "guid": "{D0C0E57A-0068-5269-B3A0-A827DD4090D9}",
+                                    "subId": 274705241
                                 },
-                                "assetHint": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.azmodel"
+                                "assetHint": "prefabs/otto600/default_otto600_1656cfa9_69f2_5d41_85db_1a4fcba4b0f5_.fbx.azmodel"
                             }
                         }
                     }
@@ -4908,7 +4847,133 @@
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15691846221364367981,
-                    "Parent Entity": "Entity_[372142146059]"
+                    "Parent Entity": "Entity_[372142146059]",
+                    "Transform Data": {
+                        "UniformScale": 0.009999999776482582
+                    }
+                }
+            }
+        },
+        "Entity_[53867428940913]": {
+            "Id": "Entity_[53867428940913]",
+            "Name": "chassis",
+            "Components": {
+                "AZ::Render::EditorMeshComponent": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 3270945428654281390,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{D0C0E57A-0068-5269-B3A0-A827DD4090D9}",
+                                    "subId": 268661737
+                                },
+                                "assetHint": "prefabs/otto600/default_otto600_a4533a21_d44d_5c0e_a25b_2e1648ad4ade_.fbx.azmodel"
+                            }
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 544057150285502687
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6531586077965411731
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1235514382533876233
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 2188915127976599391
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15121884590352162101
+                },
+                "EditorMaterialComponent": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 13570587953096653072,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 48421206
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{73AD6398-0854-5467-839E-7E0AF9A25146}"
+                                            },
+                                            "assetHint": "prefabs/otto600/otto600_emission03.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 114592210
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{BC11CF39-9966-5086-BAAA-67410FCC66B8}"
+                                            },
+                                            "assetHint": "prefabs/otto600/otto600_emission02.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 1355161694
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{8505748C-1422-57A0-BA40-5E817F0EBBCA}"
+                                            },
+                                            "assetHint": "prefabs/otto600/otto600_emission01.azmaterial"
+                                        }
+                                    }
+                                },
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 3373457715
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{A39B27FE-9F92-52CA-A9A5-E5A707BDF6AA}"
+                                            },
+                                            "assetHint": "prefabs/otto600/otto600_otto600.azmaterial"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4591162971207547223
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13066348973541846704
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1347097501921190582
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5818932725488436259,
+                    "Parent Entity": "Entity_[415091819019]",
+                    "Transform Data": {
+                        "UniformScale": 0.009999999776482582
+                    }
                 }
             }
         }


### PR DESCRIPTION
![Screenshot from 2023-10-19 19-48-20](https://github.com/RobotecAI/ROSCon2023Demo/assets/31925544/a6597ed0-1ad5-48dc-bbe6-25671a217c42)

- Fixed wheel visualization in OTTO600
- New lights for OTTO1500
- Some material and visual improvements
- Moved lidars from base_link_visual to base_link (in all OTTOs)
![Screenshot from 2023-10-19 19-48-50](https://github.com/RobotecAI/ROSCon2023Demo/assets/31925544/f7f650e8-bf61-4f5d-8864-757a4ba816c0)


It covers #213 