### PR TITLE
Update prefabs with the ROS2FrameEditorComponent

### DIFF
--- a/Project/Assets/Importer/OTTO1500_Basic_platform.prefab
+++ b/Project/Assets/Importer/OTTO1500_Basic_platform.prefab
@@ -86,13 +86,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15925498669316666254
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15123522658220298039,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 1224177359147313595,
@@ -133,6 +126,11 @@
                             89.99998474121094
                         ]
                     }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15123522658220298039,
+                    "ROS2FrameConfiguration": {}
                 }
             }
         },
@@ -171,13 +169,6 @@
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15925498669316666254
-                },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15123522658220298039,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
                 },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
@@ -219,6 +210,11 @@
                             -89.99999237060547
                         ]
                     }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15123522658220298039,
+                    "ROS2FrameConfiguration": {}
                 }
             }
         },
@@ -427,15 +423,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 16022502127876327237
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 7074193684611987849,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FL",
-                        "Joint Name": "wheel_FL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 4980933094791522169,
@@ -446,6 +433,14 @@
                             0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 7074193684611987849,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FL",
+                        "Joint Name": "wheel_FL_joint"
                     }
                 }
             }
@@ -562,15 +557,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 2443215881953371120
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9575629714018252231,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FR",
-                        "Joint Name": "wheel_FR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 3306116615541045982,
@@ -581,6 +567,14 @@
                             -0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9575629714018252231,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FR",
+                        "Joint Name": "wheel_FR_joint"
                     }
                 }
             }
@@ -867,19 +861,18 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13299598668537444244
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5938297682992751890,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "basic_platform",
-                        "Joint Name": "platform_base_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7014737032381896820,
                     "Parent Entity": "Entity_[2519474926107]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 5938297682992751890,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "basic_platform",
+                        "Joint Name": "platform_base_joint"
+                    }
                 }
             }
         },
@@ -999,15 +992,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15605763167411938660
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 4368675647580221482,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CL",
-                        "Joint Name": "wheel_CL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 10920974858884699363,
@@ -1018,6 +1002,14 @@
                             0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 4368675647580221482,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CL",
+                        "Joint Name": "wheel_CL_joint"
                     }
                 }
             }
@@ -1227,15 +1219,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 11001398732714682120
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 4304561535272682067,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RL",
-                        "Joint Name": "wheel_RL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 18235508899209137899,
@@ -1246,6 +1229,14 @@
                             0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 4304561535272682067,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RL",
+                        "Joint Name": "wheel_RL_joint"
                     }
                 }
             }
@@ -1362,15 +1353,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 12024648280213412067
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5067399526360475740,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RR",
-                        "Joint Name": "wheel_RR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9594692668350466101,
@@ -1381,6 +1363,14 @@
                             -0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 5067399526360475740,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RR",
+                        "Joint Name": "wheel_RR_joint"
                     }
                 }
             }
@@ -1727,15 +1717,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 17014673235571821016
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 13899866913334024191,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CR",
-                        "Joint Name": "wheel_CR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15489604726587043544,
@@ -1746,6 +1727,14 @@
                             -0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 13899866913334024191,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CR",
+                        "Joint Name": "wheel_CR_joint"
                     }
                 }
             }
@@ -1980,14 +1969,6 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6097697814265899899,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "base_link"
-                    }
-                },
                 "ROS2RobotControlComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 5405402406463899881,
@@ -2052,6 +2033,13 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15848641852368889391,
                     "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 6097697814265899899,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "base_link"
+                    }
                 }
             }
         },

--- a/Project/Assets/Importer/OTTO1500_Lifting_platform.prefab
+++ b/Project/Assets/Importer/OTTO1500_Lifting_platform.prefab
@@ -569,19 +569,18 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 8543309040253375687
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 7797953199747721465,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "lifting_platform_base",
-                        "Joint Name": "platform_base_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 11008486067540714881,
                     "Parent Entity": "Entity_[1110725653019]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 7797953199747721465,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "lifting_platform_base",
+                        "Joint Name": "platform_base_joint"
+                    }
                 }
             }
         },
@@ -697,15 +696,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 17042451770518661582
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15653938197853869814,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FR",
-                        "Joint Name": "wheel_FR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 12507719300496607560,
@@ -716,6 +706,14 @@
                             -0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15653938197853869814,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FR",
+                        "Joint Name": "wheel_FR_joint"
                     }
                 }
             }
@@ -950,14 +948,6 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 846486765456039724,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "base_link"
-                    }
-                },
                 "ROS2RobotControlComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 17648677164910155783,
@@ -1022,6 +1012,13 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 1914697465706863652,
                     "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 846486765456039724,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "base_link"
+                    }
                 }
             }
         },
@@ -1317,15 +1314,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 7132290279820186428
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2315639252914940096,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RR",
-                        "Joint Name": "wheel_RR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 6287139759018839719,
@@ -1336,6 +1324,14 @@
                             -0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 2315639252914940096,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RR",
+                        "Joint Name": "wheel_RR_joint"
                     }
                 }
             }
@@ -1452,15 +1448,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 599570099933479308
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1405255309136561180,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FL",
-                        "Joint Name": "wheel_FL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 111102903236116066,
@@ -1471,6 +1458,14 @@
                             0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1405255309136561180,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FL",
+                        "Joint Name": "wheel_FL_joint"
                     }
                 }
             }
@@ -1587,15 +1582,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15724415939963540995
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 4825142281503736763,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RL",
-                        "Joint Name": "wheel_RL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 3042598401775737989,
@@ -1606,6 +1592,14 @@
                             0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 4825142281503736763,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RL",
+                        "Joint Name": "wheel_RL_joint"
                     }
                 }
             }
@@ -1726,15 +1720,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10970369165200603987
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5094852104546283434,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CR",
-                        "Joint Name": "wheel_CR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 664031309524572220,
@@ -1745,6 +1730,14 @@
                             -0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 5094852104546283434,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CR",
+                        "Joint Name": "wheel_CR_joint"
                     }
                 }
             }
@@ -1997,15 +1990,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 16676920975958166214
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6493275290702354821,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "lift_module",
-                        "Joint Name": "lift_module_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7457908842884477803,
@@ -2016,6 +2000,14 @@
                             0.0,
                             0.3799999952316284
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 6493275290702354821,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "lift_module",
+                        "Joint Name": "lift_module_joint"
                     }
                 }
             }
@@ -2136,15 +2128,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 497181137057921449
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15574975046981210750,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CL",
-                        "Joint Name": "wheel_CL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2381514613129010332,
@@ -2155,6 +2138,14 @@
                             0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15574975046981210750,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CL",
+                        "Joint Name": "wheel_CL_joint"
                     }
                 }
             }
@@ -2365,19 +2356,18 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 7624992504638885429,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "lift_upper",
-                        "Joint Name": "lift_upper_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7231204767050711257,
                     "Parent Entity": "Entity_[1097840751131]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 7624992504638885429,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "lift_upper",
+                        "Joint Name": "lift_upper_joint"
+                    }
                 }
             }
         },
@@ -2602,13 +2592,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13633123171021996394
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9805679993737794881,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 12388909980958955215,
@@ -2649,6 +2632,11 @@
                             -89.99999237060547
                         ]
                     }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9805679993737794881,
+                    "ROS2FrameConfiguration": {}
                 }
             }
         },
@@ -4984,13 +4972,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13633123171021996394
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9805679993737794881,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 12388909980958955215,
@@ -5031,6 +5012,11 @@
                             89.99998474121094
                         ]
                     }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9805679993737794881,
+                    "ROS2FrameConfiguration": {}
                 }
             }
         }

--- a/Project/Assets/Importer/ur10.prefab
+++ b/Project/Assets/Importer/ur10.prefab
@@ -98,16 +98,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3162201113938073911
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11215053288689314569,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "flange",
-                        "Joint Name": "wrist_3-flange",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 400995838768749823,
@@ -118,6 +108,15 @@
                             0.000001707547198748216,
                             -90.00000762939453
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11215053288689314569,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "flange",
+                        "Joint Name": "wrist_3-flange",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -293,16 +292,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 14178936275163388283
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6725714804015519141,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "tool0",
-                        "Joint Name": "flange-tool0",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 12372534703390537978,
@@ -313,6 +302,15 @@
                             89.99996185302734,
                             0.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 6725714804015519141,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "tool0",
+                        "Joint Name": "flange-tool0",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -526,19 +524,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 2900401725638520869
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1337278135579268774,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "forearm_link",
-                        "Joint Name": "elbow_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 8412104066248939483,
@@ -554,6 +539,18 @@
                             -9.039679602072037e-29,
                             -1.5166065725475662e-21
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1337278135579268774,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "forearm_link",
+                        "Joint Name": "elbow_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -763,19 +760,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 14891883367921573398
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15791815753167737967,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "wrist_3_link",
-                        "Joint Name": "wrist_3_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 3868267867187415994,
@@ -791,6 +775,18 @@
                             -1.3559519403108056e-28,
                             3.791516178933426e-22
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15791815753167737967,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_3_link",
+                        "Joint Name": "wrist_3_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -900,19 +896,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 11110003518163621478
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11750197844762334575,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "shoulder_link",
-                        "Joint Name": "shoulder_pan_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 14238198336063306324,
@@ -923,6 +906,18 @@
                             0.0,
                             0.12729999423027039
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11750197844762334575,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "shoulder_link",
+                        "Joint Name": "shoulder_pan_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1120,19 +1115,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 4447019963576809044
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11919293354833549866,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "wrist_2_link",
-                        "Joint Name": "wrist_2_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 14125838079395442588,
@@ -1148,6 +1130,18 @@
                             -1.5166065725475662e-21,
                             -7.0167078561561656e-15
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11919293354833549866,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_2_link",
+                        "Joint Name": "wrist_2_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1244,19 +1238,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3577927265296436934
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 3643723356448930267,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "base_link_inertia",
-                        "Joint Name": "base_link-base_link_inertia",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 16706756367717092850,
@@ -1267,6 +1248,18 @@
                             0.0,
                             180.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 3643723356448930267,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "base_link_inertia",
+                        "Joint Name": "base_link-base_link_inertia",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1316,18 +1309,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 4882093382413089942
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2647709708475378771,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "base",
-                        "Joint Name": "base_link-base_fixed_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 8282631054892688013,
@@ -1338,6 +1319,17 @@
                             0.0,
                             180.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 2647709708475378771,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "base",
+                        "Joint Name": "base_link-base_fixed_joint"
                     }
                 }
             }
@@ -1452,19 +1444,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15346349257908877517
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 8821592955977444905,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "wrist_1_link",
-                        "Joint Name": "wrist_1_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 8727709477175995643,
@@ -1475,6 +1454,18 @@
                             -4.470348358154297e-8,
                             0.16394098103046417
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 8821592955977444905,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "wrist_1_link",
+                        "Joint Name": "wrist_1_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1649,22 +1640,21 @@
                         "Action name": "joint_trajectory_controller/follow_joint_trajectory"
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16030547047118712638,
+                    "Parent Entity": "Entity_[2844844128358]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 4167489356847728006,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },
                         "Frame Name": "base_link",
                         "Joint Name": "base_joint"
                     }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 16030547047118712638,
-                    "Parent Entity": "Entity_[2844844128358]"
                 }
             }
         },
@@ -1783,19 +1773,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 12870955700656991821
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2428354820031729224,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 1
-                        },
-                        "Frame Name": "upper_arm_link",
-                        "Joint Name": "shoulder_lift_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 10121638506472911477,
@@ -1806,6 +1783,18 @@
                             -7.0167078561561656e-15,
                             3.7915164313689154e-22
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 2428354820031729224,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "upper_arm_link",
+                        "Joint Name": "shoulder_lift_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1978,16 +1967,6 @@
                         "$type": "GripperActionServerComponent"
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9111996756983695701,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "gripper_link",
-                        "Joint Name": "tool0-gripper",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 14197983517855441119,
@@ -2012,6 +1991,15 @@
                         "$type": "VacuumGripperComponent",
                         "EffectorCollider": "Entity_[2840549161062]",
                         "EffectorArticulation": "Entity_[2840549161062]"
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9111996756983695701,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "gripper_link",
+                        "Joint Name": "tool0-gripper",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -2063,22 +2051,21 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 9697593403581928237
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15731962174482153453,
+                    "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 9761504380790994395,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },
                         "Frame Name": "world",
                         "Publish Transform": false
                     }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 15731962174482153453,
-                    "Parent Entity": "ContainerEntity"
                 }
             }
         },
@@ -2287,16 +2274,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 534106856007224175
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 16309935774288793114,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "ft_frame",
-                        "Joint Name": "wrist_3_link-ft_frame",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2109512160091696786,
@@ -2307,6 +2284,15 @@
                             -6.392019448087837e-29,
                             -3.1960067147783805e-29
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 16309935774288793114,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "ft_frame",
+                        "Joint Name": "wrist_3_link-ft_frame",
+                        "Publish Transform": false
                     }
                 }
             }

--- a/Project/Assets/Importer/ur20.prefab
+++ b/Project/Assets/Importer/ur20.prefab
@@ -89,22 +89,21 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 690398386269314164
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7361833121527235019,
+                    "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 5240521757725247983,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },
                         "Frame Name": "world",
                         "Publish Transform": false
                     }
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 7361833121527235019,
-                    "Parent Entity": "ContainerEntity"
                 }
             }
         },
@@ -376,16 +375,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 14178936275163388283
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6725714804015519141,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "tool0",
-                        "Joint Name": "flange-tool0",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 12372534703390537978,
@@ -396,6 +385,15 @@
                             89.99996185302734,
                             0.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 6725714804015519141,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "tool0",
+                        "Joint Name": "flange-tool0",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -479,16 +477,6 @@
                         "$type": "GripperActionServerComponent"
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9111996756983695701,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "gripper_link",
-                        "Joint Name": "tool0-gripper",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 14197983517855441119,
@@ -513,6 +501,15 @@
                         "$type": "VacuumGripperComponent",
                         "EffectorCollider": "Entity_[7277583976930]",
                         "EffectorArticulation": "Entity_[7277583976930]"
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9111996756983695701,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "gripper_link",
+                        "Joint Name": "tool0-gripper",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -632,16 +629,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15782491215964799077
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 3083845678868066117,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "forearm_link",
-                        "Joint Name": "elbow_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 8343753668865873521,
@@ -657,6 +644,15 @@
                             -9.039679602072037e-29,
                             -1.5166065725475662e-21
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 3083845678868066117,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "forearm_link",
+                        "Joint Name": "elbow_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -955,16 +951,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 7444936094356350361
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11103590891730747664,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wrist_1_link",
-                        "Joint Name": "wrist_1_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2729287346078457237,
@@ -975,6 +961,15 @@
                             -2.9802322387695313e-8,
                             0.20100001990795135
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11103590891730747664,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wrist_1_link",
+                        "Joint Name": "wrist_1_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1083,16 +1078,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3106518939751339603
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 17639613658207484215,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wrist_2_link",
-                        "Joint Name": "wrist_2_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 17677009970489914270,
@@ -1108,6 +1093,15 @@
                             -1.5166065725475662e-21,
                             -7.0167078561561656e-15
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 17639613658207484215,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wrist_2_link",
+                        "Joint Name": "wrist_2_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1227,16 +1221,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 9940279564102040212
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9293043279228032287,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "upper_arm_link",
-                        "Joint Name": "shoulder_lift_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 16759217769144000533,
@@ -1247,6 +1231,15 @@
                             -7.0167078561561656e-15,
                             3.7915164313689154e-22
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9293043279228032287,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "upper_arm_link",
+                        "Joint Name": "shoulder_lift_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1427,16 +1420,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 4296747952673902477
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 491013427572720828,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "shoulder_link",
-                        "Joint Name": "shoulder_pan_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 11681556027088341968,
@@ -1452,6 +1435,15 @@
                             0.0,
                             180.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 491013427572720828,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "shoulder_link",
+                        "Joint Name": "shoulder_pan_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1591,16 +1583,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3162201113938073911
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11215053288689314569,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "flange",
-                        "Joint Name": "wrist_3-flange",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 400995838768749823,
@@ -1611,6 +1593,15 @@
                             0.0,
                             -90.00000762939453
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11215053288689314569,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "flange",
+                        "Joint Name": "wrist_3-flange",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -1914,18 +1905,17 @@
                         "Action name": "joint_trajectory_controller/follow_joint_trajectory"
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 10808114954278001120,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "base_link"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 18356661809412537335,
                     "Parent Entity": "Entity_[1060644049743]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 10808114954278001120,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "base_link"
+                    }
                 }
             }
         },
@@ -2045,16 +2035,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 12640989737706851468
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 11393412447853053353,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wrist_3_link",
-                        "Joint Name": "wrist_3_joint",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 3799957344903901769,
@@ -2070,6 +2050,15 @@
                             -5.649799751295023e-29,
                             3.791516178933426e-22
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 11393412447853053353,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wrist_3_link",
+                        "Joint Name": "wrist_3_joint",
+                        "Publish Transform": false
                     }
                 }
             }
@@ -2118,16 +2107,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 534106856007224175
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 16309935774288793114,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "ft_frame",
-                        "Joint Name": "wrist_3_link-ft_frame",
-                        "Publish Transform": false
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2109512160091696786,
@@ -2143,6 +2122,15 @@
                             -9.588028570278648e-29,
                             2.2696220215697066e-35
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 16309935774288793114,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "ft_frame",
+                        "Joint Name": "wrist_3_link-ft_frame",
+                        "Publish Transform": false
                     }
                 }
             }

--- a/Project/CameraDropPickupDropPark.prefab
+++ b/Project/CameraDropPickupDropPark.prefab
@@ -179,14 +179,6 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15092627223095051452,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "camera_drop"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 11340372032319460387,
@@ -202,6 +194,13 @@
                             0.0,
                             -89.99994659423828
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15092627223095051452,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "camera_drop"
                     }
                 }
             }
@@ -251,14 +250,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 11893509090435207875
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 673973100445986234,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "Pickup"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7155344431639955871,
@@ -269,6 +260,13 @@
                             3.090829610824585,
                             0.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 673973100445986234,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "Pickup"
                     }
                 }
             }
@@ -318,14 +316,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 7534089191044523442
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 14459931361656117788,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "Drop"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9599094991467190531,
@@ -341,6 +331,13 @@
                             0.0,
                             -89.99991607666016
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 14459931361656117788,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "Drop"
                     }
                 }
             }
@@ -390,14 +387,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 4720855398655358834
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1586225048509550916,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "Park"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 3973755322994343354,
@@ -408,6 +397,13 @@
                             -3.733273506164551,
                             0.0
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1586225048509550916,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "Park"
                     }
                 }
             }

--- a/Project/Levels/DemoLevel1/DemoLevel1.prefab
+++ b/Project/Levels/DemoLevel1/DemoLevel1.prefab
@@ -2461,12 +2461,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur4"
                 },
                 {
@@ -2861,12 +2861,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur1"
                 },
                 {
@@ -2896,12 +2896,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur2"
                 },
                 {
@@ -2931,12 +2931,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur3"
                 },
                 {

--- a/Project/Levels/DemoLevel2/DemoLevel2.prefab
+++ b/Project/Levels/DemoLevel2/DemoLevel2.prefab
@@ -6503,12 +6503,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur4"
                 },
                 {
@@ -6941,12 +6941,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur8"
                 }
             ]
@@ -6976,12 +6976,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur5"
                 }
             ]
@@ -7026,12 +7026,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur7"
                 }
             ]
@@ -7076,12 +7076,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur6"
                 }
             ]
@@ -7141,12 +7141,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur9"
                 }
             ]
@@ -7206,12 +7206,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur10"
                 }
             ]
@@ -7241,12 +7241,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur12"
                 }
             ]
@@ -7291,12 +7291,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur11"
                 }
             ]
@@ -7316,12 +7316,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur1"
                 },
                 {
@@ -7361,12 +7361,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur2"
                 },
                 {
@@ -7396,12 +7396,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur3"
                 },
                 {

--- a/Project/Levels/DemoLevel3/DemoLevel3.prefab
+++ b/Project/Levels/DemoLevel3/DemoLevel3.prefab
@@ -8490,12 +8490,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur4"
                 },
                 {
@@ -9699,12 +9699,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur8"
                 }
             ]
@@ -9734,12 +9734,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur5"
                 }
             ]
@@ -9814,12 +9814,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur7"
                 }
             ]
@@ -10200,12 +10200,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur6"
                 }
             ]
@@ -10310,12 +10310,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur1"
                 },
                 {
@@ -10345,12 +10345,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur2"
                 },
                 {
@@ -10380,12 +10380,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur3"
                 },
                 {

--- a/Project/Levels/tmp2/tmp2.prefab
+++ b/Project/Levels/tmp2/tmp2.prefab
@@ -4664,12 +4664,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur4"
                 },
                 {
@@ -5445,12 +5445,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur1"
                 },
                 {
@@ -5480,12 +5480,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur2"
                 },
                 {
@@ -5515,12 +5515,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Instances/Instance_[8954793939791]/Entities/Entity_[1060644049743]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur3"
                 },
                 {

--- a/Project/Prefabs/HumanNpcRobot.prefab
+++ b/Project/Prefabs/HumanNpcRobot.prefab
@@ -225,16 +225,6 @@
                         "Angular Speed": 2.0
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 18218766782150271155,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 2
-                        }
-                    }
-                },
                 "ROS2RobotControlComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 16948776265117773660,
@@ -256,6 +246,15 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2507038620276963239,
                     "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 18218766782150271155,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 2
+                        }
+                    }
                 }
             }
         }

--- a/Project/Prefabs/OTTO600/OTTO600.prefab
+++ b/Project/Prefabs/OTTO600/OTTO600.prefab
@@ -86,14 +86,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13229562046516333863
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1021054117381513344,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "sensor_frame_front"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 7190873393897941808,
@@ -135,6 +127,13 @@
                             0.0,
                             89.99993133544922
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1021054117381513344,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "sensor_frame_front"
                     }
                 }
             }
@@ -350,14 +349,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13229562046516333863
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1021054117381513344,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "sensor_frame_rear"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 7190873393897941808,
@@ -399,6 +390,13 @@
                             0.0,
                             -90.00000762939453
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1021054117381513344,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "sensor_frame_rear"
                     }
                 }
             }
@@ -2457,13 +2455,6 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 10196926479865051977,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9757860202562385162,
@@ -2475,6 +2466,11 @@
                             0.23825424909591675
                         ]
                     }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 10196926479865051977,
+                    "ROS2FrameConfiguration": {}
                 }
             }
         },
@@ -2754,15 +2750,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10525064806730949353
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1685195339242614254,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CR",
-                        "Joint Name": "wheel_CR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 13836189155380994256,
@@ -2773,6 +2760,14 @@
                             -0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1685195339242614254,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CR",
+                        "Joint Name": "wheel_CR_joint"
                     }
                 }
             }
@@ -2904,15 +2899,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3368377533465026419
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5901806679755793469,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RL",
-                        "Joint Name": "wheel_RL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 5235209443845363675,
@@ -2923,6 +2909,14 @@
                             0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 5901806679755793469,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RL",
+                        "Joint Name": "wheel_RL_joint"
                     }
                 }
             }
@@ -3208,14 +3202,6 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 17397470648387535370,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "base_link"
-                    }
-                },
                 "ROS2OdometrySensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 16264798095579696439,
@@ -3297,6 +3283,13 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 10263502672085348284,
                     "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 17397470648387535370,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "base_link"
+                    }
                 }
             }
         },
@@ -3488,15 +3481,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 6731356225539671618
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1355237814141417055,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FR",
-                        "Joint Name": "wheel_FR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2571948534174782925,
@@ -3507,6 +3491,14 @@
                             -0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1355237814141417055,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FR",
+                        "Joint Name": "wheel_FR_joint"
                     }
                 }
             }
@@ -3707,19 +3699,18 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10910652991628068510
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2174180570441989848,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "platform_base",
-                        "Joint Name": "platform_base_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 8278872072752172593,
                     "Parent Entity": "Entity_[376437113355]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 2174180570441989848,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "platform_base",
+                        "Joint Name": "platform_base_joint"
+                    }
                 }
             }
         },
@@ -3850,19 +3841,18 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 13247078055354917866,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "platform_upper",
-                        "Joint Name": "platform_upper_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9707263786250240503,
                     "Parent Entity": "Entity_[402206917131]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 13247078055354917866,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "platform_upper",
+                        "Joint Name": "platform_upper_joint"
+                    }
                 }
             }
         },
@@ -4258,15 +4248,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 7105857519706516029
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6579705276849537004,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CL",
-                        "Joint Name": "wheel_CL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2859753127298735767,
@@ -4277,6 +4258,14 @@
                             0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 6579705276849537004,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CL",
+                        "Joint Name": "wheel_CL_joint"
                     }
                 }
             }
@@ -4469,15 +4458,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 1402539732528279026
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1951075038113589187,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RR",
-                        "Joint Name": "wheel_RR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 238562926451881307,
@@ -4488,6 +4468,14 @@
                             -0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1951075038113589187,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RR",
+                        "Joint Name": "wheel_RR_joint"
                     }
                 }
             }
@@ -4770,15 +4758,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10963743580669993920
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 360826664265524752,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FL",
-                        "Joint Name": "wheel_FL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 361678751970872990,
@@ -4789,6 +4768,14 @@
                             0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 360826664265524752,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FL",
+                        "Joint Name": "wheel_FL_joint"
                     }
                 }
             }

--- a/Project/Prefabs/OTTO600/OTTO600WithPallet.prefab
+++ b/Project/Prefabs/OTTO600/OTTO600WithPallet.prefab
@@ -196,12 +196,12 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "otto_1"
                 },
                 {

--- a/Project/Prefabs/ur10_cameras.prefab
+++ b/Project/Prefabs/ur10_cameras.prefab
@@ -120,17 +120,17 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[2844844128358]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "path": "/Entities/Entity_[2844844128358]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace Strategy",
                     "value": 3
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[2844844128358]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "path": "/Entities/Entity_[2844844128358]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Namespace Configuration/Namespace",
                     "value": "ur1"
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[2844844128358]/Components/ROS2FrameComponent/m_template/Publish Transform",
+                    "path": "/Entities/Entity_[2844844128358]/Components/ROS2FrameEditorComponent/ROS2FrameConfiguration/Publish Transform",
                     "value": true
                 },
                 {
@@ -305,21 +305,6 @@
                                 "Id": 4720855398655358834,
                                 "VisibilityFlag": true
                             },
-                            "ROS2FrameComponent": {
-                                "$type": "GenericComponentWrapper",
-                                "Id": 1586225048509550916,
-                                "m_template": {
-                                    "$type": "ROS2FrameComponent",
-                                    "Id": 0,
-                                    "Namespace Configuration": {
-                                        "Namespace Strategy": 0,
-                                        "Namespace": ""
-                                    },
-                                    "Frame Name": "Park",
-                                    "Joint Name": "",
-                                    "Publish Transform": true
-                                }
-                            },
                             "TransformComponent": {
                                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                                 "Id": 3973755322994343354,
@@ -347,6 +332,20 @@
                                 "IsStatic": false,
                                 "InterpolatePosition": 0,
                                 "InterpolateRotation": 0
+                            },
+                            "ROS2FrameEditorComponent": {
+                                "$type": "ROS2FrameEditorComponent",
+                                "Id": 1586225048509550916,
+                                "ROS2FrameConfiguration": {
+                                    "Id": 0,
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "Park",
+                                    "Joint Name": "",
+                                    "Publish Transform": true
+                                }
                             }
                         },
                         "IsRuntimeActive": true
@@ -402,21 +401,6 @@
                                 "Id": 7534089191044523442,
                                 "VisibilityFlag": true
                             },
-                            "ROS2FrameComponent": {
-                                "$type": "GenericComponentWrapper",
-                                "Id": 14459931361656117788,
-                                "m_template": {
-                                    "$type": "ROS2FrameComponent",
-                                    "Id": 0,
-                                    "Namespace Configuration": {
-                                        "Namespace Strategy": 0,
-                                        "Namespace": ""
-                                    },
-                                    "Frame Name": "Drop",
-                                    "Joint Name": "",
-                                    "Publish Transform": true
-                                }
-                            },
                             "TransformComponent": {
                                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                                 "Id": 9599094991467190531,
@@ -444,6 +428,20 @@
                                 "IsStatic": false,
                                 "InterpolatePosition": 0,
                                 "InterpolateRotation": 0
+                            },
+                            "ROS2FrameEditorComponent": {
+                                "$type": "ROS2FrameEditorComponent",
+                                "Id": 14459931361656117788,
+                                "ROS2FrameConfiguration": {
+                                    "Id": 0,
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "Drop",
+                                    "Joint Name": "",
+                                    "Publish Transform": true
+                                }
                             }
                         },
                         "IsRuntimeActive": true
@@ -499,21 +497,6 @@
                                 "Id": 11893509090435207875,
                                 "VisibilityFlag": true
                             },
-                            "ROS2FrameComponent": {
-                                "$type": "GenericComponentWrapper",
-                                "Id": 673973100445986234,
-                                "m_template": {
-                                    "$type": "ROS2FrameComponent",
-                                    "Id": 0,
-                                    "Namespace Configuration": {
-                                        "Namespace Strategy": 0,
-                                        "Namespace": ""
-                                    },
-                                    "Frame Name": "Pickup",
-                                    "Joint Name": "",
-                                    "Publish Transform": true
-                                }
-                            },
                             "TransformComponent": {
                                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                                 "Id": 7155344431639955871,
@@ -541,6 +524,20 @@
                                 "IsStatic": false,
                                 "InterpolatePosition": 0,
                                 "InterpolateRotation": 0
+                            },
+                            "ROS2FrameEditorComponent": {
+                                "$type": "ROS2FrameEditorComponent",
+                                "Id": 673973100445986234,
+                                "ROS2FrameConfiguration": {
+                                    "Id": 0,
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "Pickup",
+                                    "Joint Name": "",
+                                    "Publish Transform": true
+                                }
                             }
                         },
                         "IsRuntimeActive": true
@@ -698,21 +695,6 @@
                                     }
                                 }
                             },
-                            "ROS2FrameComponent": {
-                                "$type": "GenericComponentWrapper",
-                                "Id": 5364483958052265547,
-                                "m_template": {
-                                    "$type": "ROS2FrameComponent",
-                                    "Id": 0,
-                                    "Namespace Configuration": {
-                                        "Namespace Strategy": 0,
-                                        "Namespace": ""
-                                    },
-                                    "Frame Name": "camera_pickup",
-                                    "Joint Name": "",
-                                    "Publish Transform": true
-                                }
-                            },
                             "TransformComponent": {
                                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                                 "Id": 17197644915412255258,
@@ -740,6 +722,20 @@
                                 "IsStatic": false,
                                 "InterpolatePosition": 0,
                                 "InterpolateRotation": 0
+                            },
+                            "ROS2FrameEditorComponent": {
+                                "$type": "ROS2FrameEditorComponent",
+                                "Id": 5364483958052265547,
+                                "ROS2FrameConfiguration": {
+                                    "Id": 0,
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "camera_pickup",
+                                    "Joint Name": "",
+                                    "Publish Transform": true
+                                }
                             }
                         },
                         "IsRuntimeActive": true
@@ -897,21 +893,6 @@
                                     }
                                 }
                             },
-                            "ROS2FrameComponent": {
-                                "$type": "GenericComponentWrapper",
-                                "Id": 15092627223095051452,
-                                "m_template": {
-                                    "$type": "ROS2FrameComponent",
-                                    "Id": 0,
-                                    "Namespace Configuration": {
-                                        "Namespace Strategy": 0,
-                                        "Namespace": ""
-                                    },
-                                    "Frame Name": "camera_drop",
-                                    "Joint Name": "",
-                                    "Publish Transform": true
-                                }
-                            },
                             "TransformComponent": {
                                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                                 "Id": 11340372032319460387,
@@ -939,6 +920,20 @@
                                 "IsStatic": false,
                                 "InterpolatePosition": 0,
                                 "InterpolateRotation": 0
+                            },
+                            "ROS2FrameEditorComponent": {
+                                "$type": "ROS2FrameEditorComponent",
+                                "Id": 15092627223095051452,
+                                "ROS2FrameConfiguration": {
+                                    "Id": 0,
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "camera_drop",
+                                    "Joint Name": "",
+                                    "Publish Transform": true
+                                }
                             }
                         },
                         "IsRuntimeActive": true

--- a/Project/Prefabs/ur20_cameras.prefab
+++ b/Project/Prefabs/ur20_cameras.prefab
@@ -210,21 +210,6 @@
                                     }
                                 }
                             },
-                            "ROS2FrameComponent": {
-                                "$type": "GenericComponentWrapper",
-                                "Id": 4145488354555654048,
-                                "m_template": {
-                                    "$type": "ROS2FrameComponent",
-                                    "Id": 0,
-                                    "Namespace Configuration": {
-                                        "Namespace Strategy": 0,
-                                        "Namespace": ""
-                                    },
-                                    "Frame Name": "camera_pickup",
-                                    "Joint Name": "",
-                                    "Publish Transform": true
-                                }
-                            },
                             "TransformComponent": {
                                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                                 "Id": 2741027279447392744,
@@ -252,6 +237,20 @@
                                 "IsStatic": false,
                                 "InterpolatePosition": 0,
                                 "InterpolateRotation": 0
+                            },
+                            "ROS2FrameEditorComponent": {
+                                "$type": "ROS2FrameEditorComponent",
+                                "Id": 4145488354555654048,
+                                "ROS2FrameConfiguration": {
+                                    "Id": 0,
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "camera_pickup",
+                                    "Joint Name": "",
+                                    "Publish Transform": true
+                                }
                             }
                         },
                         "IsRuntimeActive": true
@@ -409,21 +408,6 @@
                                     }
                                 }
                             },
-                            "ROS2FrameComponent": {
-                                "$type": "GenericComponentWrapper",
-                                "Id": 920434809922726795,
-                                "m_template": {
-                                    "$type": "ROS2FrameComponent",
-                                    "Id": 0,
-                                    "Namespace Configuration": {
-                                        "Namespace Strategy": 0,
-                                        "Namespace": ""
-                                    },
-                                    "Frame Name": "camera_drop",
-                                    "Joint Name": "",
-                                    "Publish Transform": true
-                                }
-                            },
                             "TransformComponent": {
                                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                                 "Id": 2552988515570240159,
@@ -451,6 +435,20 @@
                                 "IsStatic": false,
                                 "InterpolatePosition": 0,
                                 "InterpolateRotation": 0
+                            },
+                            "ROS2FrameEditorComponent": {
+                                "$type": "ROS2FrameEditorComponent",
+                                "Id": 920434809922726795,
+                                "ROS2FrameConfiguration": {
+                                    "Id": 0,
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "camera_drop",
+                                    "Joint Name": "",
+                                    "Publish Transform": true
+                                }
                             }
                         },
                         "IsRuntimeActive": true


### PR DESCRIPTION
**Breaking change**
This PR is in reference to https://github.com/o3de/o3de-extras/pull/593.

I've updated all prefabs to include the ROS2FrameEditorComponent instead of the ROS2FrameComponent.