### PR TITLE
move object detector from OTTO Gem

### DIFF
--- a/Project/Assets/Factory/Objects/WarehouseObjects_300m2.prefab
+++ b/Project/Assets/Factory/Objects/WarehouseObjects_300m2.prefab
@@ -12662,7 +12662,7 @@
             ]
         },
         "Instance_[6417398750869]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -12687,7 +12687,7 @@
             ]
         },
         "Instance_[6425988685461]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -12712,7 +12712,7 @@
             ]
         },
         "Instance_[6451758489237]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -12737,7 +12737,7 @@
             ]
         },
         "Instance_[6473233325717]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",

--- a/Project/Assets/Factory/Objects/WarehouseObjects_900m2.prefab
+++ b/Project/Assets/Factory/Objects/WarehouseObjects_900m2.prefab
@@ -3052,7 +3052,7 @@
             ]
         },
         "Instance_[6417398750869]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3077,7 +3077,7 @@
             ]
         },
         "Instance_[6425988685461]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3102,7 +3102,7 @@
             ]
         },
         "Instance_[6451758489237]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3127,7 +3127,7 @@
             ]
         },
         "Instance_[6473233325717]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",

--- a/Project/Prefabs/Features/Lines.prefab
+++ b/Project/Prefabs/Features/Lines.prefab
@@ -3079,7 +3079,7 @@
     },
     "Instances": {
         "Instance_[37349376312084]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3109,7 +3109,7 @@
             ]
         },
         "Instance_[37357966246676]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3179,7 +3179,7 @@
             ]
         },
         "Instance_[37362261213972]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3209,7 +3209,7 @@
             ]
         },
         "Instance_[37383736050452]": {
-            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Source": "Prefabs/OTTO600/Otto600StandWithPaths.prefab",
             "Patches": [
                 {
                     "op": "replace",

--- a/Project/Prefabs/OTTO600/OTTO600WithPallet.prefab
+++ b/Project/Prefabs/OTTO600/OTTO600WithPallet.prefab
@@ -133,6 +133,36 @@
                     "value": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.stl.azmodel"
                 },
                 {
+                    "op": "add",
+                    "path": "/Entities/Entity_[376437113355]/Components/EditorEntitySortComponent/Child Entity Order/10",
+                    "value": "Entity_[54180626568149]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[376437113355]/Components/EditorTagComponent/Id",
+                    "value": 7864192969969983559
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 3
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
+                    "value": "otto_1"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[376437113355]/Components/ROS2OdometrySensorComponent/m_template/SensorConfiguration/Publishers/nav_msgs::msg::Odometry/QoS/Reliability",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[376437113355]/Components/SkidSteeringModelComponent/m_template/ManualControl",
+                    "value": false
+                },
+                {
                     "op": "replace",
                     "path": "/Entities/Entity_[385027047947]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/assetHint",
                     "value": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.stl.azmodel"
@@ -166,11 +196,6 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[415091819019]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/assetHint",
-                    "value": "prefabs/otto600/otto600.fbx.azmodel"
-                },
-                {
-                    "op": "replace",
                     "path": "/Entities/Entity_[427976720907]/Components/AZ::Render::EditorMeshComponent/Controller/Configuration/ModelAsset/assetHint",
                     "value": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.stl.azmodel"
                 },
@@ -190,39 +215,261 @@
                     "value": "assets/urdfimporter/3514951866_otto600.urdf/otto600_wheel.stl.azmodel"
                 },
                 {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[376437113355]/Components/EditorTagComponent/Id",
-                    "value": 7864192969969983559
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 3
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[376437113355]/Components/ROS2FrameComponent/m_template/Namespace Configuration/Namespace",
-                    "value": "otto_1"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[376437113355]/Components/ROS2OdometrySensorComponent/m_template/SensorConfiguration/Publishers/nav_msgs::msg::Odometry/QoS/Reliability",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[376437113355]/Components/SkidSteeringModelComponent/m_template/ManualControl",
-                    "value": false
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[187685058540532]/Components/ROS2Lidar2DSensorComponent/m_template/lidarCore/lidarConfiguration/lidarImplementation",
-                    "value": "Scene Queries"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[207905764570100]/Components/ROS2Lidar2DSensorComponent/m_template/lidarCore/lidarConfiguration/lidarImplementation",
-                    "value": "Scene Queries"
+                    "op": "add",
+                    "path": "/Entities/Entity_[54180626568149]",
+                    "value": {
+                        "Id": "Entity_[54180626568149]",
+                        "Name": "object_detector",
+                        "Components": {
+                            "EditorColliderComponent": {
+                                "$type": "EditorColliderComponent",
+                                "Id": 6854363288055062962,
+                                "ColliderConfiguration": {
+                                    "CollisionLayer": {
+                                        "Index": 0
+                                    },
+                                    "CollisionGroupId": {
+                                        "GroupId": "{00000000-0000-0000-0000-000000000000}"
+                                    },
+                                    "Visible": false,
+                                    "Trigger": true,
+                                    "Simulated": false,
+                                    "DummySimulated": false,
+                                    "InSceneQueries": false,
+                                    "Exclusive": true,
+                                    "Position": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "Rotation": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        1.0
+                                    ],
+                                    "MaterialSlots": {
+                                        "Slots": [
+                                            {
+                                                "Name": "Entire object",
+                                                "MaterialAsset": {
+                                                    "assetId": {
+                                                        "guid": "{00000000-0000-0000-0000-000000000000}",
+                                                        "subId": 0
+                                                    },
+                                                    "loadBehavior": "QueueLoad",
+                                                    "assetHint": ""
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "propertyVisibilityFlags": 255,
+                                    "ColliderTag": "",
+                                    "RestOffset": 0.0,
+                                    "ContactOffset": 0.019999999552965164
+                                },
+                                "ShapeConfiguration": {
+                                    "ShapeType": 1,
+                                    "Sphere": {
+                                        "Scale": [
+                                            1.0,
+                                            1.0,
+                                            1.0
+                                        ],
+                                        "Radius": 0.5
+                                    },
+                                    "Box": {
+                                        "Scale": [
+                                            1.0,
+                                            1.0,
+                                            1.0
+                                        ],
+                                        "Configuration": [
+                                            0.9599999785423279,
+                                            0.6600000262260437,
+                                            0.4100000262260437
+                                        ]
+                                    },
+                                    "Capsule": {
+                                        "Scale": [
+                                            1.0,
+                                            1.0,
+                                            1.0
+                                        ],
+                                        "Height": 1.0,
+                                        "Radius": 0.25
+                                    },
+                                    "Cylinder": {
+                                        "Configuration": {
+                                            "Scale": [
+                                                1.0,
+                                                1.0,
+                                                1.0
+                                            ],
+                                            "CookedData": "",
+                                            "Type": 0
+                                        },
+                                        "Subdivision": 16,
+                                        "Height": 1.0,
+                                        "Radius": 1.0
+                                    },
+                                    "PhysicsAsset": {
+                                        "Asset": {
+                                            "assetId": {
+                                                "guid": "{00000000-0000-0000-0000-000000000000}",
+                                                "subId": 0
+                                            },
+                                            "loadBehavior": "QueueLoad",
+                                            "assetHint": ""
+                                        },
+                                        "Configuration": {
+                                            "Scale": [
+                                                1.0,
+                                                1.0,
+                                                1.0
+                                            ],
+                                            "PhysicsAsset": {
+                                                "assetId": {
+                                                    "guid": "{00000000-0000-0000-0000-000000000000}",
+                                                    "subId": 0
+                                                },
+                                                "loadBehavior": "PreLoad",
+                                                "assetHint": ""
+                                            },
+                                            "AssetScale": [
+                                                1.0,
+                                                1.0,
+                                                1.0
+                                            ],
+                                            "UseMaterialsFromAsset": true,
+                                            "SubdivisionLevel": 4
+                                        }
+                                    },
+                                    "HasNonUniformScale": false,
+                                    "SubdivisionLevel": 4
+                                },
+                                "DebugDrawSettings": {
+                                    "LocallyEnabled": true
+                                },
+                                "ComponentMode": {},
+                                "HasNonUniformScale": false
+                            },
+                            "EditorDisabledCompositionComponent": {
+                                "$type": "EditorDisabledCompositionComponent",
+                                "Id": 4753111068839598502,
+                                "DisabledComponents": []
+                            },
+                            "EditorEntityIconComponent": {
+                                "$type": "EditorEntityIconComponent",
+                                "Id": 10490828475784569905,
+                                "EntityIconAssetId": {
+                                    "guid": "{00000000-0000-0000-0000-000000000000}",
+                                    "subId": 0
+                                }
+                            },
+                            "EditorEntitySortComponent": {
+                                "$type": "EditorEntitySortComponent",
+                                "Id": 9372273277445168672,
+                                "Child Entity Order": []
+                            },
+                            "EditorInspectorComponent": {
+                                "$type": "EditorInspectorComponent",
+                                "Id": 3690054499056523947,
+                                "ComponentOrderEntryArray": []
+                            },
+                            "EditorLockComponent": {
+                                "$type": "EditorLockComponent",
+                                "Id": 17720957739415143807,
+                                "Locked": false
+                            },
+                            "EditorOnlyEntityComponent": {
+                                "$type": "EditorOnlyEntityComponent",
+                                "Id": 7445437583515820557,
+                                "IsEditorOnly": false
+                            },
+                            "EditorPendingCompositionComponent": {
+                                "$type": "EditorPendingCompositionComponent",
+                                "Id": 18054888955575320038,
+                                "PendingComponents": []
+                            },
+                            "EditorStaticRigidBodyComponent": {
+                                "$type": "EditorStaticRigidBodyComponent",
+                                "Id": 16584477294899253114
+                            },
+                            "EditorVisibilityComponent": {
+                                "$type": "EditorVisibilityComponent",
+                                "Id": 1226463308874167519,
+                                "VisibilityFlag": true
+                            },
+                            "ObjectDetectionComponent": {
+                                "$type": "GenericComponentWrapper",
+                                "Id": 10739369858074313712,
+                                "m_template": {
+                                    "$type": "ObjectDetectionComponent",
+                                    "Id": 0,
+                                    "ObjectDetectionConfig": {
+                                        "CollisionTrigger": "Entity_[54180626568149]",
+                                        "DetectableObjects": [
+                                            "AMR"
+                                        ],
+                                        "TopicConfiguration": {
+                                            "Type": "std_msgs::msg::Empty",
+                                            "Topic": "/object_detector",
+                                            "QoS": {
+                                                "Reliability": 1,
+                                                "Durability": 2,
+                                                "Depth": 5
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "ROS2FrameComponent": {
+                                "$type": "GenericComponentWrapper",
+                                "Id": 1859594132773617675,
+                                "m_template": {
+                                    "$type": "ROS2FrameComponent",
+                                    "Id": 0,
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "sensor_frame",
+                                    "Joint Name": "",
+                                    "Publish Transform": true
+                                }
+                            },
+                            "TransformComponent": {
+                                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                                "Id": 15485897771088290664,
+                                "Parent Entity": "Entity_[376437113355]",
+                                "Transform Data": {
+                                    "Translate": [
+                                        1.0264878273010254,
+                                        0.0,
+                                        0.23825424909591675
+                                    ],
+                                    "Rotate": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "Scale": [
+                                        1.0,
+                                        1.0,
+                                        1.0
+                                    ],
+                                    "Locked": false,
+                                    "UniformScale": 1.0
+                                },
+                                "Parent Activation Transform Mode": 0,
+                                "IsStatic": false,
+                                "InterpolatePosition": 0,
+                                "InterpolateRotation": 0
+                            }
+                        },
+                        "IsRuntimeActive": true
+                    }
                 }
             ]
         },

--- a/Project/Prefabs/OTTO600/Otto600StandWithPaths.prefab
+++ b/Project/Prefabs/OTTO600/Otto600StandWithPaths.prefab
@@ -1,0 +1,376 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Otto600StandWithPaths",
+        "Components": {
+            "EditorDisabledCompositionComponent": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 10234755415255832145
+            },
+            "EditorEntityIconComponent": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 10739627318463705748
+            },
+            "EditorEntitySortComponent": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 15195870473928458851,
+                "Child Entity Order": [
+                    "Entity_[52539605976417]",
+                    "Entity_[1183842649220968]",
+                    "Instance_[52986282575201]/ContainerEntity"
+                ]
+            },
+            "EditorInspectorComponent": {
+                "$type": "EditorInspectorComponent",
+                "Id": 13493061329524281845
+            },
+            "EditorLockComponent": {
+                "$type": "EditorLockComponent",
+                "Id": 5178644815331053181
+            },
+            "EditorOnlyEntityComponent": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 4434795210006652519
+            },
+            "EditorPendingCompositionComponent": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 5652096222468439116
+            },
+            "EditorPrefabComponent": {
+                "$type": "EditorPrefabComponent",
+                "Id": 5486108095508835721
+            },
+            "EditorVisibilityComponent": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 6714601725215791159
+            },
+            "TransformComponent": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 5377832758936688593,
+                "Parent Entity": "",
+                "Transform Data": {
+                    "Translate": [
+                        -12.288918495178223,
+                        29.508747100830078,
+                        0.0
+                    ]
+                }
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1183842649220968]": {
+            "Id": "Entity_[1183842649220968]",
+            "Name": "Paths",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8198738860413026534
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4281074361593793820
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5566944012329862519,
+                    "Child Entity Order": [
+                        "Entity_[1183889893861224]",
+                        "Entity_[1184100347258728]"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6888323102124459313
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17494711138315142660
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2260459185746717047
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9630771515267560911
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8911658762927933760
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8492714779783113000,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            -0.10000000149011612,
+                            0.5,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[1183889893861224]": {
+            "Id": "Entity_[1183889893861224]",
+            "Name": "ApproachPickup",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6328750808442596061
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3917817524395130710
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9723870717274429523
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5364358427671654386
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2436532969249163790
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14151125551357815656
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14067893785351465934
+                },
+                "EditorSplineComponent": {
+                    "$type": "EditorSplineComponent",
+                    "Id": 12129646135826817445,
+                    "Configuration": {
+                        "Spline": {
+                            "Vertices": {
+                                "Vertices": [
+                                    [
+                                        2.377629518508911,
+                                        2.297909736633301,
+                                        0.0
+                                    ],
+                                    [
+                                        0.0,
+                                        2.2779669761657715,
+                                        0.0
+                                    ],
+                                    {}
+                                ]
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9662762426758840392
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11011049576307696029,
+                    "Parent Entity": "Entity_[1183842649220968]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.08600807189941406,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[1184100347258728]": {
+            "Id": "Entity_[1184100347258728]",
+            "Name": "EvacuateFromPickup",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5606086264869323794
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2546020342784463669
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8003090929144997865
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 18420521555632046603
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8960091896076734562
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8866182329801877236
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12541106030025073685
+                },
+                "EditorSplineComponent": {
+                    "$type": "EditorSplineComponent",
+                    "Id": 2511086606071557925,
+                    "Configuration": {
+                        "Spline": {
+                            "Vertices": {
+                                "Vertices": [
+                                    {},
+                                    [
+                                        0.0,
+                                        2.286928653717041,
+                                        0.0
+                                    ],
+                                    [
+                                        1.0,
+                                        2.282466411590576,
+                                        0.0
+                                    ]
+                                ]
+                            }
+                        }
+                    }
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11768051817785553238
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12655920849449538914,
+                    "Parent Entity": "Entity_[1183842649220968]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.087310791015625,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[52539605976417]": {
+            "Id": "Entity_[52539605976417]",
+            "Name": "Collider",
+            "Components": {
+                "EditorColliderComponent": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17919037474505791342,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            0.23000000417232513
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                1.0,
+                                0.10000000149011612,
+                                0.46000000834465027
+                            ]
+                        }
+                    }
+                },
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 11506697290539911975
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7639470040654753584
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2949548790484137032
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12021226270993890131
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7747864513806056711
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11265956670682517927
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 992945677344486651
+                },
+                "EditorStaticRigidBodyComponent": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9205487875057867692
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4870727882401207504
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5781754649269959855,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            -0.00800000037997961,
+                            0.0
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "Instances": {
+        "Instance_[52986282575201]": {
+            "Source": "OTTO600/Stand/Otto600Stand.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Parent Entity",
+                    "value": "../ContainerEntity"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/0",
+                    "value": 0.0
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/1",
+                    "value": 0.6000000238418579
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/TransformComponent/Transform Data/Translate/2",
+                    "value": 2.384185791015625e-7
+                },
+                {
+                    "op": "remove",
+                    "path": "/Entities/Entity_[3817754087158]/Components/EditorMeshColliderComponent"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
- The object detector component in OTTO600 is removed in OTTO Gem as it is part of the demo. It is added as an _override_ in the demo.
- Colliders in OTTO600 Stand in OTTO Gem are modified and do not work with the demo. An appropriate collider is added as an _override_ in this PR. 

Requires the [updated OTTO Gem}(https://github.com/RobotecAI/o3de-otto-robots-gem/pull/4) to work.