### PR TITLE
Add Github templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,32 @@
+**Describe the issue**
+A clear and concise description of what the issue is. Try to isolate the issue to help the community to reproduce it easily and increase chances for a fast fix.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+A clear and concise description of what actually happened.
+
+**Steps to reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+**Screenshots/Video**
+If applicable, add screenshots and/or a video to help explain your problem.
+
+**Found in Branches**
+Names of or links to the branches where the issue occurs. Please provide the SHA/hash that identifies the latest commit if necessary; tag should be enough for [o3de/o3de](https://github.com/o3de/o3de) and [o3de/o3de-extras](https://github.com/o3de/o3de-extras), as the demo is expected to run with the stable releases of o3de.
+ - this demo:
+ - o3de:
+ - o3de-extras: 
+
+**Desktop/Device (please complete the following information):**
+ - OS [e.g. Windows 10 22H2, Ubuntu 22.04]
+ - CPU [e.g. Intel I9-9900k, Ryzen 5900x, ]
+ - GPU [AMD 6800 XT, NVidia RTX 3090]
+ - Memory [e.g. 16GB]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## What does this PR do?
+
+_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_
+
+_Please add links to any issues, RFCs or other items that are relevant to this PR._
+
+## How was this PR tested?
+
+_Please describe any testing performed._


### PR DESCRIPTION
Add Github `issue template` and `pull request template`.

The `pull request template` is copied from [main o3de repository](https://github.com/o3de/o3de/blob/development/.github/pull_request_template.md)

The `issue template` is a modified `bug issue template` from [main o3de repository](https://github.com/o3de/o3de/blob/development/.github/ISSUE_TEMPLATE/bug_template.md). This demo is provided as is, which means no features or deprecation issues are expected.