### PR TITLE
Fix compile issue with the latest version o fthe humble debian packages:

### DIFF
--- a/Project/project.json
+++ b/Project/project.json
@@ -22,7 +22,7 @@
     "gem_names": [
         "HumanWorker==2.0.0",
         "OTTORobots==2.0.0",
-        "ROS2==3.1.0",
+        "ROS2>=3.1.0",
         "URRobots==2.0.0",
         "WarehouseAssets",
         "WarehouseAutomation"

--- a/ros2_ws/setup_submodules.bash
+++ b/ros2_ws/setup_submodules.bash
@@ -21,7 +21,7 @@ then
 	git checkout humble
 	if [ $? -ne 0 ]
 	then
-		echo "Failed to checkout ROS 2 iron branch."
+		echo "Failed to checkout ROS 2 humble branch."
 		exit 1
 	fi
 

--- a/ros2_ws/setup_submodules.bash
+++ b/ros2_ws/setup_submodules.bash
@@ -17,6 +17,14 @@ then
 	# submodule init and update are sufficient for humble
 	git submodule init
 	git submodule update
+	cd ./src/Universal_Robots_ROS2_Driver/
+	git checkout humble
+	if [ $? -ne 0 ]
+	then
+		echo "Failed to checkout ROS 2 iron branch."
+		exit 1
+	fi
+
 elif [ -z "$ROS_DISTRO" ]
 then
 	echo "ROS 2 distribution not found."


### PR DESCRIPTION
## What does this PR do?

With the latest install of the ros humble debian packages on ubuntu 22.04, the following error occurs in the `Universal_Robots_ROS2_Driver` module:
```
-- stderr: ur_controllers
/data/workspace/ROSCon2023Demo/ros2_ws/src/Universal_Robots_ROS2_Driver/ur_controllers/src/scaled_joint_trajectory_controller.cpp: In member function ‘virtual controller_interface::return_type ur_controllers::ScaledJointTrajectoryController::update(const rclcpp::Time&, const rclcpp::Duration&)’:
/data/workspace/ROSCon2023Demo/ros2_ws/src/Universal_Robots_ROS2_Driver/ur_controllers/src/scaled_joint_trajectory_controller.cpp:160:7: error: ‘traj_point_active_ptr_’ was not declared in this scope
  160 |   if (traj_point_active_ptr_ && (*traj_point_active_ptr_)->has_trajectory_msg()) {
      |       ^~~~~~~~~~~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/ur_controllers.dir/build.make:76: CMakeFiles/ur_controllers.dir/src/scaled_joint_trajectory_controller.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[1]: *** [CMakeFiles/Makefile2:223: CMakeFiles/ur_controllers.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< ur_controllers [8.19s, exited with code 2]
```
There was a 'humble' branch in that repo that fixes this issue.

## How was this PR tested?
Successfully built on Ubuntu 22.04 and ROS humble
