### PR TITLE
Update UR Driver submodule; add release note

### DIFF
--- a/Project/project.json
+++ b/Project/project.json
@@ -1,6 +1,6 @@
 {
     "project_name": "ROSCon2023Demo",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "project_id": "{C930C5B9-4B70-40B7-88F4-A7E927D6A677}",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",

--- a/README.md
+++ b/README.md
@@ -344,6 +344,10 @@ Please also refer to the common [Troubleshooting Guide](https://docs.o3de.org/do
 
 ## Release notes
 
+### ROSCon2023Demo 2.0.1 for O3DE 2409.x
+Changes compared to 2.0.0:
+- updated UR ROS2 Driver (external) submodule
+
 ### ROSCon2023Demo 2.0.0 for O3DE 2409.x
 Changes compared to 1.0.1:
 - updated demo the newest available version of O3DE and ROS 2 Gem
@@ -356,7 +360,7 @@ Changes compared to 1.0.1:
 ### ROSCon2023Demo 1.0.1 for O3DE 2310.x
 Changes compared to 1.0.0:
 - enforced versions of dependencies (HumanWorker, OTTORobots, URRobots)
-- updated UR (external) submodule
+- updated UR ROS2 Driver (external) submodule
 - updated README
 
 ### ROSCon2023Demo 1.0.0 for O3DE 2310.x


### PR DESCRIPTION
## What does this PR do?

Closes #310 

This PR is targeting the `main` branch and introducing a new patch release. This is caused by changes in ROS 2 API. The change will be backported to the development branch when accepted. The only change in this PR is an update of `Universal Robots ROS2 Driver` submodule (and information about it in the README). The project's version was bumped accordingly, the tag will be added after the PR is merged.

## How was this PR tested?

The ROS 2 workspace was built and the simulation was tested. UR moves as expected.